### PR TITLE
Test Suites "Tests" percentages

### DIFF
--- a/src/pageComponents/team/id/tests/TestSummaryRow.tsx
+++ b/src/pageComponents/team/id/tests/TestSummaryRow.tsx
@@ -17,15 +17,24 @@ export function TestSummaryRow({
 
   let icon: ReactNode = null;
   if (showFlakyRate) {
-    icon = (
-      <div className="flex items-center justify-center bg-yellow-500 text-black w-full h-6 rounded-md shrink-0 text-xs">
-        {Math.round(testSummary.stats.flakyRate * 100)}%
-      </div>
-    );
+    if (testSummary.stats.flakyRate > 0) {
+      icon = (
+        <div className="flex items-center justify-center bg-yellow-500 text-black w-full h-6 rounded-md shrink-0 text-xs">
+          {Math.ceil(testSummary.stats.flakyRate * 100)}%
+        </div>
+      );
+    } else {
+      icon = (
+        <Icon
+          className="text-green-500 w-6 h-6 shrink-0"
+          type="passing-test-run"
+        />
+      );
+    }
   } else if (testSummary.stats.failureRate > 0) {
     icon = (
       <div className="flex items-center justify-center bg-rose-600 text-white w-full h-6 rounded-md shrink-0 text-xs">
-        {Math.round(testSummary.stats.failureRate * 100)}%
+        {Math.ceil(testSummary.stats.failureRate * 100)}%
       </div>
     );
   } else {


### PR DESCRIPTION
Change two things about Test Suites "Tests" view:
* Use `Math.ceil` (instead of `Math.round`) when computing flaky/failed % so that we'd never show "0%"
* Show checks for truly 0% flaky tests, even in "sort by" flaky view. (I don't know why the sort-by-flaky view was initially implemented the other way, but it always seemed weird to me.)

I don't think it's worth making these same changes to the legacy dashboard since it should be going away soon.

| Before | After |
| :--- | :--- |
| ![Screenshot 2024-04-07 at 9 43 21 AM](https://github.com/replayio/dashboard/assets/29597/50d6b9f1-cb60-4ebe-91e3-344b6466913f) | ![Screenshot 2024-04-07 at 9 40 13 AM](https://github.com/replayio/dashboard/assets/29597/5f68ce40-d403-4dac-b387-f44383bd7552) |
| ![Screenshot 2024-04-07 at 9 42 48 AM](https://github.com/replayio/dashboard/assets/29597/b5b96afe-f61c-4dc7-97f4-3fee2930f4ed) | ![Screenshot 2024-04-07 at 9 41 37 AM](https://github.com/replayio/dashboard/assets/29597/74c6bcc0-6221-4035-88d7-c7f33f9cc59c) |

cc @jonbell-lot23, @jasonLaster 