### PR TITLE
Move server-side cookie setting logic into utils/cookie

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,16 +1,36 @@
+import cookie, { CookieSerializeOptions } from "cookie";
+import { NextResponse } from "next/server";
+
 export function deleteCookieValueClient(name: string) {
-  document.cookie = name + "=; expires=-1; Max-Age=-99999999; path=/; SameSite=Lax";
+  document.cookie =
+    name + "=; expires=-1; Max-Age=-99999999; path=/; SameSite=Lax";
 }
 
-export function getCookieValueClient(name: string): string | null {
+export function getCookieValueClient<Type = string>(name: string): Type | null {
   const value =
     document.cookie.match("(^|;)\\s*" + name + "\\s*=\\s*([^;]+)")?.pop() ??
     null;
-  return value !== null ? JSON.parse(value) : null;
+  return value !== null ? (JSON.parse(value) as Type) : null;
 }
 
 export function setCookieValueClient(name: string, value: any) {
   document.cookie = `${name}=${JSON.stringify(value)}; path=/; SameSite=Lax`;
+}
+
+export function setCookieValueServer(
+  response: NextResponse,
+  name: string,
+  value: any,
+  options?: CookieSerializeOptions
+) {
+  response.headers.append(
+    "Set-Cookie",
+    cookie.serialize(name, JSON.stringify(value), {
+      path: "/",
+      sameSite: "lax",
+      ...options,
+    })
+  );
 }
 
 export interface AccessTokenCookie {


### PR DESCRIPTION
It's easy to get confused about how cookies work on NextJS (you have to read and write them very differently in a client component, server component, or shared component rendering on the server). To simplify this, I've been trying to keep the cooking read/write logic in a `utils/cookie` method.