### PR TITLE
Ensure mock GraphQL data persists between navigations

### DIFF
--- a/src/globalMutableState.ts
+++ b/src/globalMutableState.ts
@@ -1,0 +1,19 @@
+import { MockGraphQLData } from "tests/mocks/types";
+
+// In a NextJS/React app, data is passed to the server via a request (path name, query parameters, and headers)
+// It is passed from the server to the client via React props and can be shared via React context
+// After a page navigation, components that were not re-rendered will still contain the previous values from the server
+// However the server will process a new request and so it will no longer have access to the previous request's values
+// This presents a challenge for state that want to follow the user as they navigate
+// Specifically the mock GraphQL response values that may be passed by an end-to-end test
+// In order for server-side methods like getServerSideProps() to access that data, we need to store it somewhere on the server
+
+let mockGraphQLData: MockGraphQLData | null = null;
+
+export function getMockGraphQLData(): MockGraphQLData | null {
+  return mockGraphQLData;
+}
+
+export function setMockGraphQLData(value: MockGraphQLData | null) {
+  mockGraphQLData = value;
+}

--- a/src/graphql/graphQLFetch.ts
+++ b/src/graphql/graphQLFetch.ts
@@ -1,4 +1,5 @@
 import { URLS } from "@/constants";
+import { getMockGraphQLData } from "@/globalMutableState";
 import {
   ApolloQueryResult,
   OperationVariables,
@@ -7,19 +8,16 @@ import {
 import assert from "assert";
 import { DocumentNode } from "graphql";
 import { getMockGraphQLResponse } from "tests/mocks/getMockGraphQLResponse";
-import { MockGraphQLData } from "tests/mocks/types";
 
 export async function graphQLFetch<
   Query,
   Variables extends OperationVariables = {}
 >({
   accessToken,
-  mockGraphQLData,
   query,
   variables = {} as Variables,
 }: {
   accessToken?: string;
-  mockGraphQLData: MockGraphQLData | null;
   query: DocumentNode | TypedDocumentNode<Query, Variables>;
   variables?: Variables;
 }): Promise<ApolloQueryResult<Query>> {
@@ -31,6 +29,7 @@ export async function graphQLFetch<
   }
 
   // Support e2e tests
+  const mockGraphQLData = getMockGraphQLData();
   const mockResponse = mockGraphQLData
     ? getMockGraphQLResponse(mockGraphQLData, query)
     : undefined;

--- a/src/graphql/queries/fulfillAuthRequest.ts
+++ b/src/graphql/queries/fulfillAuthRequest.ts
@@ -10,8 +10,6 @@ export async function fulfillAuthRequest(id: string, token: string) {
     FulfillAuthRequestMutation,
     FulfillAuthRequestMutationVariables
   >({
-    // TODO Support e2e test mock mutations
-    mockGraphQLData: null,
     query: gql`
       mutation FulfillAuthRequest(
         $secret: String!

--- a/src/graphql/queries/getCurrentUser.ts
+++ b/src/graphql/queries/getCurrentUser.ts
@@ -6,16 +6,12 @@ import { graphQLFetch } from "@/graphql/graphQLFetch";
 import { gql } from "@apollo/client";
 import { MockGraphQLData } from "tests/mocks/types";
 
-export async function getCurrentUser(
-  accessToken: string,
-  mockGraphQLData: MockGraphQLData | null
-) {
+export async function getCurrentUser(accessToken: string) {
   const { data, errors } = await graphQLFetch<
     GetUserQuery,
     GetUserQueryVariables
   >({
     accessToken,
-    mockGraphQLData,
     query: gql`
       query GetUser {
         viewer {

--- a/src/graphql/queries/getWorkplaceMemberRoles.ts
+++ b/src/graphql/queries/getWorkplaceMemberRoles.ts
@@ -4,21 +4,18 @@ import {
 } from "@/graphql/generated/graphql";
 import { graphQLFetch } from "@/graphql/graphQLFetch";
 import { gql } from "@apollo/client";
-import { MockGraphQLData } from "tests/mocks/types";
 
 type MemberRoles = { id: string; roles: string[] };
 
 export async function getWorkplaceMemberRoles(
   workspaceId: string,
-  accessToken: string,
-  mockGraphQLData: MockGraphQLData | null
+  accessToken: string
 ): Promise<MemberRoles[]> {
   const { data, errors } = await graphQLFetch<
     GetWorkspaceMemberRolesQuery,
     GetWorkspaceMemberRolesQueryVariables
   >({
     accessToken,
-    mockGraphQLData,
     query: gql`
       query GetWorkspaceMemberRoles($workspaceId: ID!) {
         node(id: $workspaceId) {

--- a/src/graphql/queries/getWorkspaceSubscriptionStatus.ts
+++ b/src/graphql/queries/getWorkspaceSubscriptionStatus.ts
@@ -5,19 +5,16 @@ import {
 import { graphQLFetch } from "@/graphql/graphQLFetch";
 import { WorkspaceSubscriptionStatus } from "@/graphql/types";
 import { gql } from "@apollo/client";
-import { MockGraphQLData } from "tests/mocks/types";
 
 export async function getWorkspaceSubscriptionStatus(
   workspaceId: string,
-  accessToken: string,
-  mockGraphQLData: MockGraphQLData | null
+  accessToken: string
 ): Promise<WorkspaceSubscriptionStatus> {
   const { data, errors } = await graphQLFetch<
     GetWorkspaceSubscriptionStatusQuery,
     GetWorkspaceSubscriptionStatusQueryVariables
   >({
     accessToken,
-    mockGraphQLData,
     query: gql`
       query GetWorkspaceSubscriptionStatus($workspaceId: ID!) {
         node(id: $workspaceId) {

--- a/src/graphql/queries/initAuthRequest.ts
+++ b/src/graphql/queries/initAuthRequest.ts
@@ -10,8 +10,6 @@ export async function initAuthRequest(key: string, source: string) {
     InitAutRequestMutation,
     InitAutRequestMutationVariables
   >({
-    // TODO Support e2e test mock mutations
-    mockGraphQLData: null,
     query: gql`
       mutation InitAutRequest($key: String!, $source: String = "browser") {
         initAuthRequest(input: { key: $key, source: $source }) {


### PR DESCRIPTION
I think this is the final piece to unlock proper end-to-end tests in #24

See the inline comment in `globalMutableState` for an explanation