### PR TITLE
Support legacy Test Suites GH bot link format

### DIFF
--- a/src/pages/team/[id]/runs/[runId].tsx
+++ b/src/pages/team/[id]/runs/[runId].tsx
@@ -1,0 +1,26 @@
+import { redirectWithState } from "@/utils/redirectWithState";
+import assert from "assert";
+import { GetServerSidePropsContext } from "next";
+
+// TODO [PRO-9]
+// TODO [PRO-256]
+// Remove this route once the Test Suites GitHub bot URL format has been updated
+
+export default function Page() {
+  return null;
+}
+
+export async function getServerSideProps(
+  context: GetServerSidePropsContext<{ id: string; runId: string }>
+) {
+  const workspaceId = context.params?.id;
+  const runId = context.params?.runId;
+
+  assert(workspaceId, "workspaceId is required");
+  assert(runId, "runId is required");
+
+  return redirectWithState({
+    context,
+    pathname: `/team/${workspaceId}/runs?testRunId=${runId}`,
+  });
+}


### PR DESCRIPTION
Stop gap fix until Test Suite GH bot URL format has been changed.

Once we're ready to delete the legacy Library code (in /devtools) we should update the GitHub bot URL format and then we can delete the redirect route.