### PR TITLE
Redirect `/team/[id]` to appropriate dashboard route

### DIFF
--- a/src/pages/team/[id]/index.tsx
+++ b/src/pages/team/[id]/index.tsx
@@ -1,0 +1,33 @@
+import { getServerSidePropsHelpers as getServerSidePropsShared } from "@/pageComponents/team/id/getServerSidePropsHelpers";
+import { redirectWithState } from "@/utils/redirectWithState";
+import { GetServerSidePropsContext } from "next";
+
+export default function Page() {
+  return null;
+}
+
+export async function getServerSideProps(
+  context: GetServerSidePropsContext<any>
+) {
+  const { invalidWorkspace, isTest, workspaceId } =
+    await getServerSidePropsShared(context);
+
+  if (invalidWorkspace) {
+    return redirectWithState({
+      context,
+      pathname: "/team/me/recordings",
+      props: {
+        workspaceId,
+      },
+    });
+  }
+  return redirectWithState({
+    context,
+    pathname: isTest
+      ? `/team/${workspaceId}/runs`
+      : `/team/${workspaceId}/recordings`,
+    props: {
+      workspaceId,
+    },
+  });
+}

--- a/src/utils/redirectWithState.ts
+++ b/src/utils/redirectWithState.ts
@@ -27,7 +27,7 @@ export function redirectWithState<Props>({
 
   const destination = `${pathname}?${new URLSearchParams({
     ...params,
-    mockGraphQLData: mockGraphQLDataString || "",
+    ...(mockGraphQLDataString && { mockGraphQLData: mockGraphQLDataString }),
   })}`;
 
   return {


### PR DESCRIPTION
I'm currently seeing this in prod when trying to access a route like this
<img width="580" alt="Screenshot 2024-04-23 at 11 25 05" src="https://github.com/replayio/dashboard/assets/9800850/437ad160-f85f-47b4-b518-e222604d64a2">

Note that I got the URL itself from one of our Notion docs so I'd consider it to be valid/working - but even without it having a historic baggage I think it's worth doing this.