### PR TITLE
Add default text color style to :root

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -23,6 +23,7 @@
   font-size: 14px;
   color-scheme: dark;
   background-color: theme("colors.slate.900");
+  color: theme("colors.white");
 
   --context-menu-item-font-size: 14px;
   --context-menu-item-padding: 0.5rem 1rem;


### PR DESCRIPTION
This was reported by a user in Plain who said their system was set to prefer "light" theme:

![image](https://github.com/replayio/dashboard/assets/29597/a4767042-9fb0-4de9-a42b-7880109241e6)

I cannot reproduce the reported behavior, and it goes against my understanding of how `color-scheme: dark` should work, but perhaps this added default `color` style will help them.