### PR TITLE
Handle AccessTokenError in token endpoint

### DIFF
--- a/src/pages/api/token.ts
+++ b/src/pages/api/token.ts
@@ -5,6 +5,10 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const { accessToken } = await getAccessToken(req, res);
-  res.status(200).send(accessToken);
+  try {
+    const { accessToken } = await getAccessToken(req, res);
+    res.status(200).send(accessToken);
+  } catch {
+    res.status(401).send("Not logged in");
+  }
 }


### PR DESCRIPTION
@bhackett1024 noticed that the `/api/token` endpoint is slow (taking around 2 seconds) when the user is not logged in. The reason seems to be that Vercel has some very slow exception handling - if we catch the exception that we get from `getAccessToken()` when the user is not logged in, then the endpoint becomes a lot faster.