### PR TITLE
Use a different env variable to enable local recording of e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:e2e": "playwright test --project=chromium",
     "test:e2e:debug": "playwright test --project=chromium --workers 1 --headed",
-    "test:e2e:record": "RECORD=1 REPLAY_PLAYWRIGHT_FIXTURE=1 playwright test --project=replay-chromium",
+    "test:e2e:record": "REPLAY_PLAYWRIGHT_FIXTURE=1 playwright test --project=replay-chromium",
     "typescript": "tsc --noEmit",
     "typescript:watch": "tsc --noEmit --watch"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  reporter: process.env.RECORD
+  reporter: process.env.REPLAY_PLAYWRIGHT_FIXTURE
     ? [
         ["line"],
         createReplayReporterConfig({


### PR DESCRIPTION
Currently, we need to call `createReplayReporterConfig` lazily. Its constructor has a side-effect that we don't want when we are not recording (it creates a websocket to establish a communication channel between node and the browser so our plugin can add annotations using RPC). This has to be fixed there but for now we workaround this problem by calling this lazily.

The problem araised when executing `pnpm test:e2e:record` locally because that was already opting into part of the whole annotations feature using `REPLAY_PLAYWRIGHT_FIXTURE=1` - its counterpart wasn't enabled though because we were calling `createReplayReporterConfig` only in presence of `process.env.CI`