### PR TITLE
tiltfile: use vendored pnpm from backend

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,17 +1,17 @@
-def dashboard(working_directory=config.main_dir, api='https://api.replay.io/v1/graphql', resource_deps=[]):
+def dashboard(dashboard_directory=config.main_dir, api='https://api.replay.io/v1/graphql', resource_deps=[]):
   local_resource(
     "dashboard deps",
-    "pnpm install",
+    os.path.join(config.main_dir, "scripts/bin/pnpm") + " install",
     deps=["package.json"],
-    dir=working_directory,
+    dir=dashboard_directory,
     allow_parallel=True
   )
   local_resource(
     "dashboard dev server",
-    serve_cmd=" pnpm dev -- -p 8080",
+    serve_cmd=os.path.join(config.main_dir, "scripts/bin/pnpm") + " dev -- -p 8080",
     deps=[],
     resource_deps=["dashboard deps"] + resource_deps,
-    serve_dir=working_directory,
+    serve_dir=dashboard_directory,
     serve_env={
         "DEVTOOLS_URL": "http://localhost:8081",
         "NEXT_PUBLIC_API_URL": api,


### PR DESCRIPTION
This is just a small change so that when we are starting the dashboard repo with Tilt we use the dotslash vendored pnpm. This would have helped with an issue @miriambudayr ran in to today.