### PR TITLE
Display email of the logged in user on the account page

### DIFF
--- a/src/pageComponents/user/settings/Account.tsx
+++ b/src/pageComponents/user/settings/Account.tsx
@@ -22,7 +22,7 @@ export function Account() {
   return (
     <div className="flex flex-col gap-2">
       <div>
-        Signed in as <span className="font-bold">{user?.name}</span>
+        Signed in as <span className="font-bold">{user.name}</span> ({user.email})
       </div>
       <div>
         <Button disabled={isPending} onClick={onClick}>


### PR DESCRIPTION
This is perhaps not something that the average user cares about. I'd like to add it because I often switch between accounts and when I'm on this page I'm not sure if I'm already on the user that I'm interested in at the given moment or not