### PR TITLE
Simplify local development (commands) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,24 @@ pnpm install
 pnpm dev
 ```
 
+### Developing against production
+
+To run Dashboard locally, paired with the production [DevTools](https://github.com/replayio/devtools) project:
+
+```sh
+pnpm dev:prod
+```
+
 ## Local development
 
 To run both the DevTools and Dashboard projects locally:
 
 ```sh
 # Dashboard root (this project)
-DEVTOOLS_URL=http://localhost:8081 pnpm dev -- -p 8080
+pnpm dev:local
 
 # DevTools root
-DASHBOARD_URL=http://localhost:8080 npm exec next dev -- -p 8081
+yarn dev:local
 ```
 
 At this point the Dashboard will be accessible at [localhost:8080](http://localhost:8080/) but it will not load recordings. To be able to test the end-to-end interaction of both apps, use [localhost:8081](http://localhost:8081/). It will serve both Dashboard and DevTools routes.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev -p 8080",
+    "dev": "npm run dev:prod",
+    "dev:local": "DEVTOOLS_URL=http://localhost:8081 pnpm dev -- -p 8080",
+    "dev:prod": "next dev -p 8080",
     "preprod": "NEXT_PUBLIC_API_URL=http://graphql-api.pre-prod.replay.prod/v1/graphql next dev -p 8080",
     "graphql": "pnpm graphql-schema && pnpm graphql-types",
     "graphql-schema": "gq https://graphql.replay.io/v1/graphql -H \"X-Hasura-Admin-Secret: $HASURA_KEY\" --introspect > schema.graphql",


### PR DESCRIPTION
Alternative deployment for #68 because that deployment seems unexpected broken

---

Pairs with https://github.com/replayio/devtools/pull/10518

This adds two dev commands: `dev:local` and `dev:prod` so that we don't have to remember the named environment parameters to pass when doing local development.

I left the existing `dev` command in place (aliased to `dev:prod`) so as not to impact RUN or BAC CI tasks.