### PR TITLE
Remove profile scope from authorization params

### DIFF
--- a/src/pages/api/auth/[auth0].ts
+++ b/src/pages/api/auth/[auth0].ts
@@ -12,7 +12,7 @@ export default handleAuth({
         audience: "https://api.replay.io",
         code_challenge_method: "S256",
         response_type: "code" as "code",
-        scope: "openid profile offline_access",
+        scope: "openid offline_access",
         prompt: getValueFromArrayOrString(req.query.prompt),
         connection: getValueFromArrayOrString(req.query.connection),
         redirect_uri: `${origin}/api/auth/callback`,


### PR DESCRIPTION
We're running into a limit on the size of HTTP headers. The problem seems to be the `Cookie` header, in particular the Auth0 cookie (or cookies - Auth0 splits its cookie into chunks if it becomes too large) that it contains.
To reduce the size of the Auth0 cookie(s), this PR removes the `profile` scope from the authorization params. This scope adds some information to the identity token but we aren't using that token anyway. When we need information about a user we fetch it from our database via GraphQL and the information is inserted into the database by an Auth0 action. I've verified that this action gets the user profile information even if we don't include the `profile` scope in the authorization params - those params seem to only influence what information is sent from Auth0 to our app but not what information Auth0 requests from Google.