### PR TITLE
Surface more high-level stats on Test Runs page

### DIFF
--- a/tests/test-suites-runs-2.spec.ts
+++ b/tests/test-suites-runs-2.spec.ts
@@ -28,8 +28,11 @@ test("test-suites-runs-2: passed run in main branch with source", async ({ page 
     expect(text).toContain("Successful run in main branch");
 
     await expect(
-      await page.locator('[data-test-id="TestRuns-Stats-FailureRateLabel"]').textContent()
-    ).toBe("Failure rate: 0%");
+      await page.locator('[data-test-id="TestRuns-Stats-RunFailureRateSummary"]').textContent()
+    ).toBe("no failed runs (1 total)");
+    await expect(
+      await page.locator('[data-test-id="TestRuns-Stats-TestFailureRateSummary"]').textContent()
+    ).toBe("no failed tests (2 total)");
 
     const column = page.locator('[data-test-name="TestRuns-Stats-DayColumn"]');
     await column.hover();

--- a/tests/test-suites-runs-3.spec.ts
+++ b/tests/test-suites-runs-3.spec.ts
@@ -29,8 +29,11 @@ test("test-suites-runs-3: failed run in temp branch without source", async ({ pa
     expect(text).toContain("Failed run in temp branch");
 
     await expect(
-      await page.locator('[data-test-id="TestRuns-Stats-FailureRateLabel"]').textContent()
-    ).toBe("Failure rate: 100%");
+      await page.locator('[data-test-id="TestRuns-Stats-RunFailureRateSummary"]').textContent()
+    ).toBe("runs failed: 100% (1 of 1)");
+    await expect(
+      await page.locator('[data-test-id="TestRuns-Stats-TestFailureRateSummary"]').textContent()
+    ).toBe("tests failed: 56% (5 of 9)");
 
     const column = page.locator('[data-test-name="TestRuns-Stats-DayColumn"]');
     await column.hover();


### PR DESCRIPTION
### Before
![Screenshot 2024-04-30 at 8 19 51 AM](https://github.com/replayio/dashboard/assets/29597/dc9b5144-95d8-4f82-ad4a-c30de24f367f)

### After
![Screenshot 2024-04-30 at 8 21 07 AM](https://github.com/replayio/dashboard/assets/29597/6408d66b-cbc0-4c80-9725-4946166268c3)
![Screenshot 2024-04-30 at 8 21 13 AM](https://github.com/replayio/dashboard/assets/29597/29e68f7a-927b-4fe8-a507-ab33f877725a)

cc @jonbell-lot23 