### PR TITLE
Remove `idToken` from auth0 session cookie

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_API_URL=https://api.replay.io
+AUTH0_SESSION_STORE_ID_TOKEN=false
 
 # Used for graphql-types
 HASURA_KEY=


### PR DESCRIPTION
Related to PRO-337. After merging it, I'll set the value in Vercel.

Removes the field `idToken` which is the largest field (because of double encoding of picture URL) that we don't use.

More context in this discord thread: https://discord.com/channels/779097926135054346/1234643097451888641