### PR TITLE
Fix bad retentionLimit check

### DIFF
--- a/src/graphql/queries/getWorkspaceType.ts
+++ b/src/graphql/queries/getWorkspaceType.ts
@@ -19,7 +19,12 @@ const QUERY = gql`
 export async function getWorkspace(
   accessToken: string,
   workspaceId: string
-): Promise<{ id: string; isOrganization: boolean; isTest: boolean; retentionLimit: number }> {
+): Promise<{
+  id: string;
+  isOrganization: boolean;
+  isTest: boolean;
+  retentionLimit: number | null;
+}> {
   const graphQLClient = getGraphQLClient(accessToken);
 
   const response = await graphQLClient.query<GetWorkspaceQuery, GetWorkspaceQueryVariables>({
@@ -35,6 +40,6 @@ export async function getWorkspace(
     id: response.data?.node.id,
     isOrganization: response.data?.node.isOrganization,
     isTest: response.data?.node.isTest,
-    retentionLimit: response.data?.node.retentionLimit ?? Number.POSITIVE_INFINITY,
+    retentionLimit: response.data?.node.retentionLimit ?? null,
   };
 }

--- a/src/graphql/queries/useNonPendingWorkspaces.ts
+++ b/src/graphql/queries/useNonPendingWorkspaces.ts
@@ -47,7 +47,7 @@ export function useNonPendingWorkspaces() {
               isOrganization: node.isOrganization,
               isTest: node.isTest,
               name: node.name,
-              retentionLimitDays: node.retentionLimit ?? Number.POSITIVE_INFINITY,
+              retentionLimitDays: node.retentionLimit ?? null,
               settings: node.settings
                 ? {
                     features: {

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -172,7 +172,7 @@ export type Workspace = {
   isOrganization: boolean;
   isTest: boolean;
   name: string;
-  retentionLimitDays: number;
+  retentionLimitDays: number | null;
   settings: WorkspaceSettings | null;
   subscriptionPlanKey: string | null;
 };

--- a/src/pageComponents/team/id/runs/TestRunsContext.tsx
+++ b/src/pageComponents/team/id/runs/TestRunsContext.tsx
@@ -42,7 +42,7 @@ export const RunsViewContext = createContext<
     isLoadingTestRuns: boolean;
     isLoadingTests: boolean;
     isPending: boolean;
-    retentionLimit: number;
+    retentionLimit: number | null;
     selectedTestRunId: string | undefined;
     selectedTestId: string | undefined;
     selectTest: (id: string) => void;
@@ -64,7 +64,7 @@ export function ContextRoot({
   filters: Partial<Filters> | null;
   defaultTestId: string | null;
   defaultTestRunId: string | null;
-  retentionLimit: number;
+  retentionLimit: number | null;
   workspaceId: string;
 }) {
   const [state, setState] = useState<Filters>({

--- a/src/pageComponents/team/id/tests/RecordingRow.tsx
+++ b/src/pageComponents/team/id/tests/RecordingRow.tsx
@@ -1,8 +1,8 @@
 import { Icon } from "@/components/Icon";
 import { TestSuiteTestExecutionRecording, TestSuiteTestStatus } from "@/graphql/types";
-import { getRelativeDate } from "@/utils/date";
 import { getURL } from "@/utils/recording";
 import { getColorClassName } from "@/utils/test-suites";
+import { isDateWithinRetentionLimits } from "@/utils/workspace";
 import Link from "next/link";
 
 export function RecordingRow({
@@ -11,15 +11,14 @@ export function RecordingRow({
   status,
 }: {
   recording: TestSuiteTestExecutionRecording;
-  retentionLimit: number;
+  retentionLimit: number | null;
   status: TestSuiteTestStatus;
 }) {
   const url = getURL(recording.id, recording.buildId);
 
   const iconType = recording.isProcessed ? "processed-recording" : "unprocessed-recording";
 
-  const isWithinRetentionLimit =
-    recording.createdAt.getTime() >= getRelativeDate({ daysAgo: retentionLimit }).getTime();
+  const isWithinRetentionLimit = isDateWithinRetentionLimits(recording.createdAt, retentionLimit);
 
   if (isWithinRetentionLimit) {
     const colorClassName = getColorClassName(status);

--- a/src/pageComponents/team/id/tests/TestsViewContext.tsx
+++ b/src/pageComponents/team/id/tests/TestsViewContext.tsx
@@ -29,7 +29,7 @@ export const TestsViewContext = createContext<
   Filters & {
     isLoading: boolean;
     isPending: boolean;
-    retentionLimit: number;
+    retentionLimit: number | null;
     selectedTestSummaryId: string | undefined;
     selectTestSummary: (id: string) => void;
     testSummaries: TestSuiteTestSummary[] | undefined;
@@ -46,7 +46,7 @@ export function ContextRoot({
 }: PropsWithChildren & {
   filters: Partial<Filters> | null;
   defaultTestSummaryId: string | null;
-  retentionLimit: number;
+  retentionLimit: number | null;
   workspaceId: string;
 }) {
   const [state, setState] = useState<Filters>({

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -1,6 +1,13 @@
 import { getRelativeDate } from "@/utils/date";
 
-export function isDateWithinRetentionLimits(date: Date, retentionLimitDays: number): boolean {
+export function isDateWithinRetentionLimits(
+  date: Date,
+  retentionLimitDays: number | null
+): boolean {
+  if (retentionLimitDays == null) {
+    return true;
+  }
+
   const minTime = getRelativeDate({ daysAgo: retentionLimitDays }).getTime();
   const time = date.getTime();
 


### PR DESCRIPTION
NextJS seems to have passed `Number.POSITIVE_INFINITY` from serve to client as `null` which broke our retention limit checks for workspaces without a retention limit. Ooof.