### PR TITLE
Updated README for env configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,21 +1,24 @@
 NEXT_PUBLIC_API_URL=https://api.replay.io
 
-# Used for graphql-types
+# Used for graphql-types; stored in 1Password
 HASURA_KEY=
 
-# Support feedback form
+# Support feedback form; stored in 1Password
 FORM_CARRY_TOKEN=
 
+# Auth0 configuration; stored in Vercel -> Environment Variables
 # auth0.com/docs/quickstart/webapp/nextjs/01-login
-AUTH0_SECRET=
-AUTH0_BASE_URL=
-AUTH0_ISSUER_BASE_URL=
+AUTH0_BASE_URL=http://localhost:8080
 AUTH0_CLIENT_ID=
 AUTH0_CLIENT_SECRET=
+AUTH0_ISSUER_BASE_URL=
+AUTH0_SECRET=
 
-# Stripe
+# Stripe; stored in Vercel -> Environment Variables
 STRIPE_KEY=
 
-# e2e test config
-APP_URL
+# e2e test config; stored in 1Password
 TEST_USER_API_KEY=
+
+# Application URL
+APP_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dashboard
 
-Standalone Replay dashboard
+Replay library hosted at [app.replay.io](https://app.replay.io)
 
 ## Getting started
 
@@ -8,12 +8,31 @@ Standalone Replay dashboard
 # Setup environment variables
 cp .env.sample .env.local
 
+# Fill in .env.local (see Configuration below)
+
 # Install dependencies
 pnpm install
 
 # Run dev server (localhost:8080)
 pnpm dev
 ```
+
+## Configuration
+
+The server reads environment variables from different places depending on where it is running:
+
+- The local server loads values from the `.env.local` file
+- Preview and production deployments load values from [Vercel Environment variables](https://vercel.com/replayio/dashboard/settings/environment-variables)
+
+Automated scripts that build preview and production deployments are configured using [GitHub secrets](https://github.com/replayio/dashboard/settings/secrets/actions).
+
+The specific URLs (hosts and paths) that support authentication are configured in the [Auth0 "Replay" project](https://manage.auth0.com/dashboard/us/webreplay/applications/4FvFnJJW4XlnUyrXQF8zOLw6vNAH1MAo/settings).
+
+The values required by the local `.env.local` file can be copied out of either [1Password](https://team-replay.1password.com/) or [Vercel Environment variables](https://vercel.com/replayio/dashboard/settings/environment-variables). When in doubt, reach out to one of the previous [contributors](https://github.com/replayio/dashboard/graphs/contributors).
+
+## Running the server
+
+In most cases, Library development can be done against the production version of [Replay DevTools](https://github.com/replayio/devtools/). However you can also run a local version of both Dashboard and DevTools.
 
 ### Developing against production
 
@@ -23,7 +42,9 @@ To run Dashboard locally, paired with the production [DevTools](https://github.c
 pnpm dev:prod
 ```
 
-## Local development
+At this point the Dashboard will be accessible at [localhost:8080](http://localhost:8080/) and will open recordings using the production deployment of the DevTools application.
+
+### Local development
 
 To run both the DevTools and Dashboard projects locally:
 


### PR DESCRIPTION
Since this project is private, we might as well make the README instructions more tailored to Replay engineers. (I don't think this exposes anything that's truly private, but these links wouldn't make sense to show to an external contributor.)

Hopefully this simplifies project configuration for new developers?