### PR TITLE
releases: also include architecture information

### DIFF
--- a/src/pages/api/releases.ts
+++ b/src/pages/api/releases.ts
@@ -2,6 +2,7 @@ import { URLS } from "@/constants";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export type Release = {
+  architecture: string | null;
   buildId: string;
   buildFile: string;
   platform: string;

--- a/src/pages/releases.tsx
+++ b/src/pages/releases.tsx
@@ -41,6 +41,9 @@ function ReleasesTable({ releases }: { releases: Release[] }) {
           <tr data-test-name="release-row" data-test-type={release.runtime} key={release.buildId}>
             <td className="min-w-24">{release.runtime}</td>
             <td className="min-w-20">{release.platform}</td>
+            <td className="min-w-20">
+              {release.architecture == null ? "unknown" : release.architecture}
+            </td>
             <td className="truncate">{release.buildId}</td>
             <td className="min-w-28">{format(new Date(release.time), "MMM d, y")}</td>
             <td className="min-w-24">


### PR DESCRIPTION
As of recently we distinguish releases by architecture in addition to build ID + operating system. Let's surface that in the UI as well.