### PR TITLE
Fix potential false positives for deep link warning dialog

### DIFF
--- a/src/hooks/useDeepLinkWarning.tsx
+++ b/src/hooks/useDeepLinkWarning.tsx
@@ -1,14 +1,19 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export function useDeepLinkWarning({
   deepLinkReferenceFound,
   isLoading,
-  urlHasDeepLink,
+  urlHasDeepLink: urlHasDeepLinkProp,
 }: {
   deepLinkReferenceFound: boolean;
   isLoading: boolean;
   urlHasDeepLink: boolean;
 }) {
+  // This prop is only meaningful during mount but URL updates may cause this value to change
+  // Using a ref helps ignore updates after mount
+  // For more details see PRO-425
+  const urlHasDeepLink = useRef(urlHasDeepLinkProp);
+
   const [{ hasLoadedInitialData, showWarning }, setState] = useState<{
     hasLoadedInitialData: boolean;
     showWarning: boolean;

--- a/src/pageComponents/team/id/runs/TestRunsContext.tsx
+++ b/src/pageComponents/team/id/runs/TestRunsContext.tsx
@@ -25,6 +25,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useTransition,
 } from "react";
@@ -113,12 +114,18 @@ export function ContextRoot({
 
   const router = useRouter();
 
+  // Next's router syncs our state to the URL asynchronously
+  // Storing a copy in this ref avoids potential timing concerns if selectTest is called before the update
+  // For more details see PRO-425
+  const mutableURLRef = useRef<URL | undefined>();
+
   const selectTest = useCallback(
     (id: string) => {
       startTransition(() => {
         setSelectedTestId(id);
 
-        const url = new URL(window.location.href);
+        const url = (mutableURLRef.current =
+          mutableURLRef.current ?? new URL(window.location.href));
         url.searchParams.set("testId", id);
 
         router.replace(url.toString());
@@ -132,7 +139,7 @@ export function ContextRoot({
       setSelectedTestRunId(id);
       setSelectedTestId(undefined);
 
-      const url = new URL(window.location.href);
+      const url = (mutableURLRef.current = mutableURLRef.current ?? new URL(window.location.href));
       url.searchParams.set("testRunId", id);
       url.searchParams.set("testId", "");
 


### PR DESCRIPTION
This commit fixes one pre-existing edge case bug (where the URL might end up with a test id but not the test run id) and one new recent regression (where changes to the URL while data was still loading could cause the deep link warning dialog to be shown when it shouldn't).