### PR TITLE
Create team and create API key bugfixes

### DIFF
--- a/src/app/ApiKeysPanel/ApiKeys.tsx
+++ b/src/app/ApiKeysPanel/ApiKeys.tsx
@@ -1,15 +1,18 @@
 import { ApiKeyRow } from "@/app/ApiKeysPanel/ApiKeyRow";
 import { CreateNewKey } from "@/app/ApiKeysPanel/CreateNewKey";
 import { ApiKey, ApiKeyScope } from "@/graphql/types";
+import { ApolloError } from "@apollo/client";
 
 export function ApiKeys({
   apiKeys,
   createKey,
+  createKeyError,
   deleteKey,
   scopes,
 }: {
   apiKeys: ApiKey[] | undefined;
-  createKey: (label: string, scopes: ApiKeyScope[]) => Promise<string>;
+  createKey: (label: string, scopes: ApiKeyScope[]) => Promise<string | undefined>;
+  createKeyError: ApolloError | undefined;
   deleteKey: (id: string) => void;
   scopes?: ApiKeyScope[];
 }) {
@@ -17,7 +20,7 @@ export function ApiKeys({
     <div className="flex flex-col gap-4 h-full overflow-auto">
       <div className="shrink-0">API Keys allow you to upload recordings programmatically.</div>
       <div className="shrink-0">
-        <CreateNewKey createKey={createKey} scopes={scopes} />
+        <CreateNewKey createKey={createKey} createKeyError={createKeyError} scopes={scopes} />
       </div>
       <div className="flex flex-col gap-1 overflow-auto shrink">
         {apiKeys && apiKeys.length > 0 && (

--- a/src/app/ApiKeysPanel/CreateNewKey.tsx
+++ b/src/app/ApiKeysPanel/CreateNewKey.tsx
@@ -3,13 +3,16 @@ import Checkbox from "@/components/Checkbox";
 import { ClickToCopyString } from "@/components/ClickToCopyString";
 import { Input } from "@/components/Input";
 import { ApiKeyScope } from "@/graphql/types";
+import { ApolloError } from "@apollo/client";
 import { useState } from "react";
 
 export function CreateNewKey({
   createKey,
+  createKeyError,
   scopes,
 }: {
-  createKey: (label: string, scopes: ApiKeyScope[]) => Promise<string>;
+  createKey: (label: string, scopes: ApiKeyScope[]) => Promise<string | undefined>;
+  createKeyError: ApolloError | undefined;
   scopes?: ApiKeyScope[];
 }) {
   const [label, setLabel] = useState("");
@@ -43,11 +46,12 @@ export function CreateNewKey({
         }
 
         const keyValue = await createKey(label, Array.from(selectedScopes));
-
-        setKeyValue(keyValue);
+        if (keyValue) {
+          setKeyValue(keyValue);
+          setLabel("");
+        }
 
         setIsPending(false);
-        setLabel("");
       }
     };
 
@@ -81,6 +85,7 @@ export function CreateNewKey({
             />
           </div>
         )}
+        {createKeyError && <div className="text-red-500">{createKeyError.message}</div>}
       </div>
     );
   }

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -37,6 +37,7 @@ export function Select<Type extends Option>({
         }}
         value={value?.label}
       >
+        {value === undefined && <option value=""></option>}
         {options.map(({ label }) => (
           <option key={label} value={label}>
             {label}

--- a/src/graphql/queries/createWorkspace.ts
+++ b/src/graphql/queries/createWorkspace.ts
@@ -4,11 +4,12 @@ import {
   CreateNewWorkspaceMutationVariables,
 } from "@/graphql/generated/graphql";
 import { getGraphQLClient } from "@/graphql/graphQLClient";
+import { QUERY } from "@/graphql/queries/useWorkspaces";
 import { gql, useMutation } from "@apollo/client";
 import assert from "assert";
 import { useContext } from "react";
 
-export function useCreateWorkspace(onCompleted: (id: string) => void, onFailed: () => void) {
+export function useCreateWorkspace() {
   const { accessToken } = useContext(SessionContext);
   assert(accessToken != null, "accessToken is required");
 
@@ -33,7 +34,10 @@ export function useCreateWorkspace(onCompleted: (id: string) => void, onFailed: 
     `,
     {
       client,
-      refetchQueries: ["GetWorkspaces"],
+      // This syntax is required to ensure Apollo refetches Workspaces after creation
+      // See github.com/apollographql/apollo-client/issues/5419#issuecomment-598065442
+      refetchQueries: [{ query: QUERY, variables: {} }],
+      awaitRefetchQueries: true,
     }
   );
 
@@ -47,9 +51,7 @@ export function useCreateWorkspace(onCompleted: (id: string) => void, onFailed: 
     });
 
     if (result.data?.createWorkspace?.workspace?.id) {
-      onCompleted(result.data?.createWorkspace?.workspace?.id);
-    } else {
-      onFailed();
+      return result.data?.createWorkspace?.workspace?.id;
     }
   };
 

--- a/src/graphql/queries/createWorkspaceAPIKey.ts
+++ b/src/graphql/queries/createWorkspaceAPIKey.ts
@@ -57,9 +57,7 @@ export function useCreateWorkspaceAPIKey() {
       variables: { apiKey, label, scopes, workspaceId },
     });
 
-    assert(response?.data?.createWorkspaceAPIKey != null, "Workspace API key creation failed");
-
-    return response.data.createWorkspaceAPIKey.keyValue;
+    return response.data?.createWorkspaceAPIKey.keyValue;
   };
 
   return { createApiKey, error, loading };

--- a/src/graphql/queries/useWorkspaces.ts
+++ b/src/graphql/queries/useWorkspaces.ts
@@ -4,36 +4,38 @@ import { useGraphQLQuery } from "@/hooks/useGraphQLQuery";
 import { gql } from "@apollo/client";
 import { useMemo } from "react";
 
-export function useWorkspaces() {
-  const { data, error, isLoading, refetch } = useGraphQLQuery<GetWorkspacesQuery>(gql`
-    query GetWorkspaces {
-      viewer {
-        workspaces {
-          edges {
-            node {
-              hasPaymentMethod
+export const QUERY = gql`
+  query GetWorkspaces {
+    viewer {
+      workspaces {
+        edges {
+          node {
+            hasPaymentMethod
+            id
+            invitationCode
+            isOrganization
+            isTest
+            name
+            retentionLimit
+            settings {
+              features
+            }
+            subscription {
               id
-              invitationCode
-              isOrganization
-              isTest
-              name
-              retentionLimit
-              settings {
-                features
-              }
-              subscription {
+              plan {
                 id
-                plan {
-                  id
-                  key
-                }
+                key
               }
             }
           }
         }
       }
     }
-  `);
+  }
+`;
+
+export function useWorkspaces() {
+  const { data, error, isLoading, refetch } = useGraphQLQuery<GetWorkspacesQuery>(QUERY);
 
   const workspaces = useMemo<Workspace[] | undefined>(() => {
     if (data) {

--- a/src/pageComponents/team/id/settings/WorkspaceApiKeys.tsx
+++ b/src/pageComponents/team/id/settings/WorkspaceApiKeys.tsx
@@ -6,13 +6,14 @@ import { ApiKeyScope } from "@/graphql/types";
 
 export function WorkspaceApiKeys({ workspaceId }: { workspaceId: string }) {
   const { apiKeys } = useGetWorkspaceApiKeys(workspaceId);
-  const { createApiKey } = useCreateWorkspaceAPIKey();
+  const { createApiKey, error } = useCreateWorkspaceAPIKey();
   const { deleteApiKey } = useDeleteWorkspaceAPIKey();
 
   return (
     <ApiKeys
       apiKeys={apiKeys}
       createKey={(label: string, scopes: ApiKeyScope[]) => createApiKey(workspaceId, label, scopes)}
+      createKeyError={error}
       deleteKey={deleteApiKey}
     />
   );

--- a/src/pageComponents/user/settings/UserApiKeys.tsx
+++ b/src/pageComponents/user/settings/UserApiKeys.tsx
@@ -8,13 +8,14 @@ export function UserApiKeys() {
   const {
     settings: { apiKeys },
   } = useGetUserSettings();
-  const { createApiKey } = useCreateUserAPIKey();
+  const { createApiKey, error } = useCreateUserAPIKey();
   const { deleteApiKey } = useDeleteUserAPIKey();
 
   return (
     <ApiKeys
       apiKeys={apiKeys}
       createKey={createApiKey}
+      createKeyError={error}
       deleteKey={deleteApiKey}
       scopes={["admin:all"]}
     />


### PR DESCRIPTION
De-coupled a few bug fixes from #92

- [x] API creation failure shows inline error message
- [x] Creating a team properly reloads Workspaces (Apollo workaround)
- [x] Re-added internal-only "bypass trial" checkbox that got accidentally removed

I'll be out for two hours around lunch time today. If you approve of this change, just merge it.