### PR TITLE
Removed Jest from Test Suite create-a-team wizard

### DIFF
--- a/src/pageComponents/team/new/tests/FormStep2.tsx
+++ b/src/pageComponents/team/new/tests/FormStep2.tsx
@@ -32,9 +32,6 @@ export function FormStep2({
       case "cypress": {
         return <CypressInstructions apiKey={apiKey} packageManager={packageManager} />;
       }
-      case "jest": {
-        return <JestInstructions packageManager={packageManager} />;
-      }
       case "playwright": {
         return <PlaywrightInstructions apiKey={apiKey} packageManager={packageManager} />;
       }
@@ -106,17 +103,6 @@ export function CypressInstructions({
           <strong className="text-yellow-400">(it will only be shown once!)</strong>
         </div>
         <CopyCode text={apiKey} />
-      </Group>
-    </>
-  );
-}
-
-export function JestInstructions({ packageManager }: { packageManager: PackageManager }) {
-  return (
-    <>
-      <Group>
-        <div>1. Install replay-node</div>
-        <Code>{getInstallCommand(packageManager, "@replayio/node", { global: true })}</Code>
       </Group>
     </>
   );

--- a/src/pageComponents/team/new/tests/FormStep3.tsx
+++ b/src/pageComponents/team/new/tests/FormStep3.tsx
@@ -18,10 +18,6 @@ export function FormStep3({
       instructions = <CypressInstructions />;
       break;
     }
-    case "jest": {
-      instructions = <JestInstructions packageManager={packageManager} />;
-      break;
-    }
     case "playwright": {
       instructions = <PlaywrightInstructions />;
       break;
@@ -48,21 +44,6 @@ export function CypressInstructions() {
     <Group>
       <strong>5. Run cypress as you normally would</strong>
       <Code>npx cypress run --browser replay-chromium</Code>
-    </Group>
-  );
-}
-
-export function JestInstructions({ packageManager }: { packageManager: PackageManager }) {
-  return (
-    <Group>
-      <strong>2. Record your tests with Replay Node</strong>
-      <div>
-        For example, to record all of the tests included by the &quot;test&quot; script in your
-        package.json:
-      </div>
-      <Code>replay-node --exec {packageManager} run test</Code>
-      <div>To filter which test files are run:</div>
-      <Code>replay-node --exec {packageManager} run test -- specific.test.ts</Code>
     </Group>
   );
 }

--- a/src/pageComponents/team/new/tests/constants.ts
+++ b/src/pageComponents/team/new/tests/constants.ts
@@ -1,6 +1,6 @@
 import { Option } from "@/components/Select";
 
-export type TestRunner = "cypress" | "jest" | "playwright";
+export type TestRunner = "cypress" | "playwright";
 export type TestRunnerOption = Option & {
   type: TestRunner;
 };
@@ -8,15 +8,11 @@ const Cypress: TestRunnerOption = {
   label: "Cypress",
   type: "cypress",
 };
-const Jest: TestRunnerOption = {
-  label: "Jest",
-  type: "jest",
-};
 const Playwright: TestRunnerOption = {
   label: "Playwright",
   type: "playwright",
 };
-export const TEST_RUNNER_OPTIONS: TestRunnerOption[] = [Cypress, Jest, Playwright];
+export const TEST_RUNNER_OPTIONS: TestRunnerOption[] = [Cypress, Playwright];
 
 export type PackageManager = "npm" | "pnpm" | "yarn";
 export type PackageManagerOption = Option & {


### PR DESCRIPTION
Replay Node isn't something we want to push right now, and the Jest approach requires it.