### PR TITLE
[TT-1228] Show both macos architectures in Latest Releases

### DIFF
--- a/src/pages/releases.tsx
+++ b/src/pages/releases.tsx
@@ -10,8 +10,8 @@ export default function Page({ releases }: InferGetServerSidePropsType<typeof ge
   const latestReleases = useMemo(() => {
     const latest: Record<string, Release> = {};
     for (const release of releases) {
-      const { runtime, platform } = release;
-      const key = `${runtime}-${platform}`;
+      const { runtime, platform, architecture } = release;
+      const key = `${runtime}-${platform}-${architecture}`;
       if (!latest[key]) {
         latest[key] = release;
       }


### PR DESCRIPTION
We're currently only showing one of the two macos chromium architectures in Latest Releases, even though both are shown in the All Releases list, e.g.:

![image](https://github.com/replayio/dashboard/assets/24245/b7209239-4179-440f-98ea-c4e4c575b556)

including the architecture in the release key should give us both macos architecture releases