### PR TITLE
Create Test Suites team UX improvements

### DIFF
--- a/src/pageComponents/team/new/tests/CopyCode.tsx
+++ b/src/pageComponents/team/new/tests/CopyCode.tsx
@@ -29,7 +29,7 @@ export function CopyCode({ text }: { text: string }) {
     if (state === "copied") {
       const id = setTimeout(() => {
         setState(undefined);
-      }, 5_000);
+      }, 2_500);
       return () => {
         clearTimeout(id);
       };
@@ -45,13 +45,14 @@ export function CopyCode({ text }: { text: string }) {
       onMouseLeave={onMouse}
     >
       <Code className="w-full hover:text-blue-400 cursor-pointer">{text}</Code>
-      <div className="absolute top-1 right-1 pointer-events-none flex flex-row gap-1 items-center text-xs">
+      <div className="absolute top-1 right-1 pointer-events-none flex flex-row items-center text-xs">
         {state === "copied" ? (
-          <span className="text-blue-400">Copied</span>
+          <span className="bg-slate-950 px-1 round text-blue-400">Copied</span>
         ) : state === "hover" ? (
-          "Copy"
-        ) : null}
-        <Icon className="w-5 h-5" type="copy" />
+          <div className="bg-slate-950 px-1 round">Copy</div>
+        ) : (
+          <Icon className="w-5 h-5" type="copy" />
+        )}
       </div>
     </div>
   );

--- a/src/pageComponents/team/new/tests/FormStep2.tsx
+++ b/src/pageComponents/team/new/tests/FormStep2.tsx
@@ -8,21 +8,15 @@ import { useMemo, useState } from "react";
 
 export function FormStep2({
   apiKey,
-  errorMessage,
   onContinue,
-  onGoBack,
   packageManager,
   testRunner,
 }: {
   apiKey: string;
-  errorMessage: string | undefined;
-  onContinue: () => Promise<boolean>;
-  onGoBack: () => void;
+  onContinue: () => void;
   packageManager: PackageManager;
   testRunner: TestRunner;
 }) {
-  const [isPending, setIsPending] = useState(false);
-
   const instructions = useMemo(() => {
     if (!packageManager || !testRunner) {
       return null;
@@ -41,37 +35,14 @@ export function FormStep2({
   return (
     <>
       {instructions}
-      {errorMessage && (
-        <div className="text-red-500" data-test-id="CreateTeam-Error" role="alert">
-          {errorMessage}
-        </div>
-      )}
-      <div className="flex flex-row gap-2">
-        <Button
-          data-test-id="CreateTeam-GoBack-Button"
-          disabled={isPending}
-          onClick={onGoBack}
-          size="large"
-          variant="outline"
-        >
-          Go back
-        </Button>
-        <Button
-          className="self-start"
-          disabled={isPending}
-          data-test-id="CreateTeam-Continue-Button"
-          onClick={async () => {
-            setIsPending(true);
-            const success = await onContinue();
-            if (!success) {
-              setIsPending(false);
-            }
-          }}
-          size="large"
-        >
-          {isPending ? "Saving..." : "Continue"}
-        </Button>
-      </div>
+      <Button
+        className="self-start"
+        data-test-id="CreateTeam-Continue-Button"
+        onClick={onContinue}
+        size="large"
+      >
+        Continue
+      </Button>
     </>
   );
 }
@@ -102,7 +73,7 @@ export function CypressInstructions({
           4. Copy this API key to your .env file;{" "}
           <strong className="text-yellow-400">(it will only be shown once!)</strong>
         </div>
-        <CopyCode text={apiKey} />
+        <CopyCode text={`REPLAY_API_KEY=${apiKey}`} />
       </Group>
     </>
   );
@@ -132,7 +103,7 @@ export function PlaywrightInstructions({
           3. Copy this API key to your .env file;{" "}
           <strong className="text-yellow-400">(it will only be shown once!)</strong>
         </div>
-        <CopyCode text={apiKey} />
+        <CopyCode text={`REPLAY_API_KEY=${apiKey}`} />
       </Group>
     </>
   );

--- a/tests/create-test-suites-team-fails.spec.ts
+++ b/tests/create-test-suites-team-fails.spec.ts
@@ -42,14 +42,6 @@ test("create-test-suites-team-fails: shows mutation error message", async ({ pag
 
     await expect(continueButton.isEnabled()).resolves.toBeTruthy();
     await continueButton.click();
-  }
-
-  {
-    // Step 2: Test runner configuration
-
-    await expect(step1.getAttribute("data-test-state")).resolves.toBe("complete");
-    await expect(step2.getAttribute("data-test-state")).resolves.toBe("current");
-    await expect(step3.getAttribute("data-test-state")).resolves.toBe("incomplete");
 
     const error = page.locator('[data-test-id="CreateTeam-Error"]');
     await expect(error.textContent()).resolves.toContain("Failed to create workspace");

--- a/tests/create-test-suites-team.spec.ts
+++ b/tests/create-test-suites-team.spec.ts
@@ -19,14 +19,12 @@ test("create-test-suites-team: create a test suites workspace", async ({ page })
 
   const form = page.locator('[data-test-id="CreateTestSuitesTeam"]');
   const continueButton = page.locator('[data-test-id="CreateTeam-Continue-Button"]');
-  const goBackButton = page.locator('[data-test-id="CreateTeam-GoBack-Button"]');
 
   const multiStepForm = page.locator('[data-test-name="MultiStepForm"]');
   const step1 = multiStepForm.locator('[data-test-name="MultiStepForm-Step-1"]');
   const step2 = multiStepForm.locator('[data-test-name="MultiStepForm-Step-2"]');
   const step3 = multiStepForm.locator('[data-test-name="MultiStepForm-Step-3"]');
 
-  await expect(goBackButton).not.toBeVisible();
   await expect(continueButton.isEnabled()).resolves.toBeFalsy();
 
   {
@@ -39,7 +37,7 @@ test("create-test-suites-team: create a test suites workspace", async ({ page })
     await page.locator('[data-test-id="CreateTestSuiteTeam-TeamName-Input"]').fill("Example");
     await page
       .locator('[data-test-id="CreateTestSuiteTeam-TestRunner-Select"]')
-      .selectOption({ label: "Playwright" });
+      .selectOption({ label: "Cypress" });
     await page
       .locator('[data-test-id="CreateTestSuiteTeam-PackageManager-Select"]')
       .selectOption({ label: "pnpm" });
@@ -55,43 +53,8 @@ test("create-test-suites-team: create a test suites workspace", async ({ page })
     await expect(step2.getAttribute("data-test-state")).resolves.toBe("current");
     await expect(step3.getAttribute("data-test-state")).resolves.toBe("incomplete");
 
-    await expect(form.textContent()).resolves.toContain("pnpm add --save-dev @replayio/playwright");
+    await expect(form.textContent()).resolves.toContain("pnpm add --save-dev @replayio/cypress");
 
-    await expect(goBackButton.isEnabled()).resolves.toBeTruthy();
-    await goBackButton.click();
-  }
-
-  {
-    // Step 1: Go back and change test runner and package manager
-
-    await expect(step1.getAttribute("data-test-state")).resolves.toBe("current");
-    await expect(step2.getAttribute("data-test-state")).resolves.toBe("incomplete");
-    await expect(step3.getAttribute("data-test-state")).resolves.toBe("incomplete");
-
-    await page
-      .locator('[data-test-id="CreateTestSuiteTeam-TestRunner-Select"]')
-      .selectOption({ label: "Cypress" });
-    await page
-      .locator('[data-test-id="CreateTestSuiteTeam-PackageManager-Select"]')
-      .selectOption({ label: "Yarn" });
-
-    await expect(continueButton.isEnabled()).resolves.toBeTruthy();
-    await continueButton.click();
-  }
-
-  {
-    // Step 2: Test runner configuration
-
-    await expect(step1.getAttribute("data-test-state")).resolves.toBe("complete");
-    await expect(step2.getAttribute("data-test-state")).resolves.toBe("current");
-    await expect(step3.getAttribute("data-test-state")).resolves.toBe("incomplete");
-
-    await expect(form.textContent()).resolves.toContain("yarn add --dev @replayio/cypress");
-
-    const apiKey = await page.locator('[data-test-name="CopyCode"]').textContent();
-    expect(apiKey?.startsWith("rwk_")).toBe(true);
-
-    await expect(continueButton.isEnabled()).resolves.toBeTruthy();
     await continueButton.click();
   }
 


### PR DESCRIPTION
### [Loom overview](https://www.loom.com/share/b479a7362fb347088d5c49fe4c6f64f2)

- [x] Move team and API key creation earlier in the wizard
- [x] Show `REPLAY_API_KEY=...` prefix in the copy box (so they'll know which `.env` name to use)