### PR TITLE
Syntax highlight code samples in create test suite team workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.13",
     "react-resizable-panels": "^2.0.19",
+    "shiki": "^1.6.0",
     "use-context-menu": "^0.4.13",
     "uuid": "^9.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ dependencies:
   react-resizable-panels:
     specifier: ^2.0.19
     version: 2.0.19(react-dom@18.2.0)(react@18.2.0)
+  shiki:
+    specifier: ^1.6.0
+    version: 1.6.0
   use-context-menu:
     specifier: ^0.4.13
     version: 0.4.13(react-dom@18.2.0)(react@18.2.0)
@@ -2821,6 +2824,10 @@ packages:
     transitivePeerDependencies:
       - zenObservable
     dev: true
+
+  /@shikijs/core@1.6.0:
+    resolution: {integrity: sha512-NIEAi5U5R7BLkbW1pG/ZKu3eb1lzc3/+jD0lFsuxMT7zjaf9bbNwdNyMr7zh/Zl8EXQtQ+MYBAt5G+JLu+5DlA==}
+    dev: false
 
   /@sideway/address@4.1.5:
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -9665,6 +9672,12 @@ packages:
       interpret: 1.4.0
       rechoir: 0.6.2
     dev: true
+
+  /shiki@1.6.0:
+    resolution: {integrity: sha512-P31ROeXcVgW/k3Z+vUUErcxoTah7ZRaimctOpzGuqAntqnnSmx1HOsvnbAB8Z2qfXPRhw61yptAzCsuKOhTHwQ==}
+    dependencies:
+      '@shikijs/core': 1.6.0
+    dev: false
 
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -1,10 +1,197 @@
-import { InputHTMLAttributes } from "react";
+import { useIsomorphicLayoutEffect } from "@/hooks/useIsomorphicLayoutEffect";
+import { InputHTMLAttributes, useState } from "react";
+import type { BundledLanguage, ThemeRegistration } from "shiki";
+import { codeToHtml } from "shiki";
 
-export function Code({ className = "", ...rest }: InputHTMLAttributes<HTMLElement>) {
+export function Code({
+  code,
+  className = "",
+  lang = "javascript",
+  ...rest
+}: InputHTMLAttributes<HTMLElement> & {
+  code: string;
+  lang?: BundledLanguage;
+}) {
+  const [html, setHTML] = useState(code);
+
+  useIsomorphicLayoutEffect(() => {
+    codeToHtml(code, {
+      lang,
+      cssVariablePrefix: "shiki",
+      theme,
+    }).then(setHTML);
+  });
+
   return (
     <code
       className={`bg-slate-950 text-white px-2 py-1 rounded whitespace-pre text-sm ${className}`}
+      dangerouslySetInnerHTML={{ __html: html }}
       {...rest}
     />
   );
 }
+
+const theme: ThemeRegistration = {
+  name: "replay",
+  colors: {
+    "editor.foreground": "var(--shiki-foreground)",
+    "editor.background": "var(--shiki-background)",
+  },
+  tokenColors: [
+    {
+      scope: [
+        "keyword.operator.accessor",
+        "meta.group.braces.round.function.arguments",
+        "meta.template.expression",
+        "markup.fenced_code meta.embedded.block",
+      ],
+      settings: {
+        foreground: "var(--shiki-foreground)",
+      },
+    },
+    {
+      scope: "emphasis",
+      settings: {
+        fontStyle: "italic",
+      },
+    },
+    {
+      scope: ["strong", "markup.heading.markdown", "markup.bold.markdown"],
+      settings: {
+        fontStyle: "bold",
+      },
+    },
+    {
+      scope: ["markup.italic.markdown"],
+      settings: {
+        fontStyle: "italic",
+      },
+    },
+    {
+      scope: "meta.link.inline.markdown",
+      settings: {
+        fontStyle: "underline",
+        foreground: "var(--shiki-token-link)",
+      },
+    },
+    {
+      scope: ["string", "markup.fenced_code", "markup.inline"],
+      settings: {
+        foreground: "var(--shiki-token-string)",
+      },
+    },
+    {
+      scope: ["comment", "string.quoted.docstring.multi"],
+      settings: {
+        foreground: "var(--shiki-token-comment)",
+      },
+    },
+    {
+      scope: [
+        "constant.numeric",
+        "constant.language",
+        "constant.other.placeholder",
+        "constant.character.format.placeholder",
+        "variable.language.this",
+        "variable.other.object",
+        "variable.other.class",
+        "variable.other.constant",
+        "meta.property-name",
+        "meta.property-value",
+        "support",
+      ],
+      settings: {
+        foreground: "var(--shiki-token-constant)",
+      },
+    },
+    {
+      scope: [
+        "keyword",
+        "storage.modifier",
+        "storage.type",
+        "storage.control.clojure",
+        "entity.name.function.clojure",
+        "entity.name.tag.yaml",
+        "support.function.node",
+        "support.type.property-name.json",
+        "punctuation.separator.key-value",
+        "punctuation.definition.template-expression",
+      ],
+      settings: {
+        foreground: "var(--shiki-token-keyword)",
+      },
+    },
+    {
+      scope: "variable.parameter.function",
+      settings: {
+        foreground: "var(--shiki-token-parameter)",
+      },
+    },
+    {
+      scope: [
+        "support.function",
+        "entity.name.type",
+        "entity.other.inherited-class",
+        "meta.function-call",
+        "meta.instance.constructor",
+        "entity.other.attribute-name",
+        "entity.name.function",
+        "constant.keyword.clojure",
+      ],
+      settings: {
+        foreground: "var(--shiki-token-function)",
+      },
+    },
+    {
+      scope: [
+        "entity.name.tag",
+        "string.quoted",
+        "string.regexp",
+        "string.interpolated",
+        "string.template",
+        "string.unquoted.plain.out.yaml",
+        "keyword.other.template",
+      ],
+      settings: {
+        foreground: "var(--shiki-token-string-expression)",
+      },
+    },
+    {
+      scope: [
+        "punctuation.definition.arguments",
+        "punctuation.definition.dict",
+        "punctuation.separator",
+        "meta.function-call.arguments",
+      ],
+      settings: {
+        foreground: "var(--shiki-token-punctuation)",
+      },
+    },
+    {
+      // [Custom] Markdown links
+      scope: ["markup.underline.link", "punctuation.definition.metadata.markdown"],
+      settings: {
+        foreground: "var(--shiki-token-link)",
+      },
+    },
+    {
+      // [Custom] Markdown list
+      scope: ["beginning.punctuation.definition.list.markdown"],
+      settings: {
+        foreground: "var(--shiki-token-string)",
+      },
+    },
+    {
+      // [Custom] Markdown punctuation definition brackets
+      scope: [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "string.other.link.title.markdown",
+        "string.other.link.description.markdown",
+      ],
+      settings: {
+        foreground: "var(--shiki-token-keyword)",
+      },
+    },
+  ],
+};

--- a/src/pageComponents/team/new/tests/CopyCode.tsx
+++ b/src/pageComponents/team/new/tests/CopyCode.tsx
@@ -2,8 +2,17 @@ import { Code } from "@/components/Code";
 import { Icon } from "@/components/Icon";
 import { copyText } from "@/utils/copy";
 import { MouseEvent, useEffect, useState } from "react";
+import type { BundledLanguage } from "shiki";
 
-export function CopyCode({ text }: { text: string }) {
+export function CopyCode({
+  className,
+  code,
+  lang,
+}: {
+  className?: string;
+  code: string;
+  lang?: BundledLanguage;
+}) {
   const [state, setState] = useState<"hover" | "copied" | undefined>();
 
   const onMouse = (event: MouseEvent<HTMLDivElement>) => {
@@ -19,7 +28,7 @@ export function CopyCode({ text }: { text: string }) {
         setState(undefined);
         break;
       case "click":
-        copyText(text);
+        copyText(code);
         setState("copied");
         break;
     }
@@ -44,7 +53,7 @@ export function CopyCode({ text }: { text: string }) {
       onMouseEnter={onMouse}
       onMouseLeave={onMouse}
     >
-      <Code className="w-full hover:text-sky-400 cursor-pointer">{text}</Code>
+      <Code className={`w-full cursor-pointer ${className}`} code={code} lang={lang} />
       <div className="absolute top-1 right-1 pointer-events-none flex flex-row items-center text-xs">
         {state === "copied" ? (
           <span className="bg-slate-950 px-1 round text-sky-400">Copied</span>

--- a/src/pageComponents/team/new/tests/FormStep1.tsx
+++ b/src/pageComponents/team/new/tests/FormStep1.tsx
@@ -15,7 +15,7 @@ import {
 import assert from "assert";
 import { useState } from "react";
 
-export function FormStep1({
+export default function FormStep1({
   defaultPackageManager,
   defaultTeamName,
   defaultTestRunner,

--- a/src/pageComponents/team/new/tests/FormStep2.tsx
+++ b/src/pageComponents/team/new/tests/FormStep2.tsx
@@ -8,7 +8,7 @@ import { PackageManager, TestRunner } from "@/pageComponents/team/new/tests/cons
 import { getInstallCommand } from "@/pageComponents/team/new/tests/getInstallCommand";
 import { useMemo } from "react";
 
-export function FormStep2({
+export default function FormStep2({
   apiKey,
   onContinue,
   packageManager,
@@ -49,7 +49,7 @@ export function FormStep2({
   );
 }
 
-export function CypressInstructions({
+function CypressInstructions({
   apiKey,
   packageManager,
 }: {
@@ -60,26 +60,28 @@ export function CypressInstructions({
     <>
       <Group>
         <div>1. Install the @replayio/cypress package in your project.</div>
-        <Code>{getInstallCommand(packageManager, "@replayio/cypress", { development: true })}</Code>
+        <CopyCode
+          code={getInstallCommand(packageManager, "@replayio/cypress", { development: true })}
+        />
       </Group>
       <Group>
         <div>2. Install the Replay browser.</div>
-        <Code>npx replayio install</Code>
+        <CopyCode code="npx replayio install" />
       </Group>
       <Group>
         <div>3. Add the Replay browser and Reporter to your cypress.config.ts file.</div>
-        <Code>{cypressConfigCode}</Code>
+        <CopyCode code={cypressConfigCode} />
       </Group>
       <SaveApiKey apiKey={apiKey} number={4} />
       <Group>
         <div>5. Import Replay to your support file.</div>
-        <Code>{`require('@replayio/cypress/support');`}</Code>
+        <CopyCode code={`require('@replayio/cypress/support');`} />
       </Group>
     </>
   );
 }
 
-export function PlaywrightInstructions({
+function PlaywrightInstructions({
   apiKey,
   packageManager,
 }: {
@@ -90,18 +92,18 @@ export function PlaywrightInstructions({
     <>
       <Group>
         <div>1. Install the @replayio/playwright package in your project.</div>
-        <Code>
-          {getInstallCommand(packageManager, "@replayio/playwright", { development: true })}
-        </Code>
+        <CopyCode
+          code={getInstallCommand(packageManager, "@replayio/playwright", { development: true })}
+        />
       </Group>
       <Group>
         <div>2. Install the Replay browser.</div>
-        <Code>npx replayio install</Code>
+        <CopyCode code="npx replayio install" />
       </Group>
       <SaveApiKey apiKey={apiKey} number={3} />
       <Group>
         <div>4. Add the Replay browser and Reporter to your playwright.config.ts file.</div>
-        <Code>{playwrightConfigCode}</Code>
+        <CopyCode code={playwrightConfigCode} />
       </Group>
     </>
   );
@@ -111,7 +113,7 @@ function SaveApiKey({ apiKey, number }: { apiKey: string; number: number }) {
   return (
     <Group>
       <div>{number}. Save the API key below before continuing.</div>
-      <CopyCode text={`REPLAY_API_KEY=${apiKey}`} />
+      <CopyCode code={`REPLAY_API_KEY=${apiKey}`} />
       <Callout
         bodyText={
           <div>

--- a/src/pageComponents/team/new/tests/FormStep3.tsx
+++ b/src/pageComponents/team/new/tests/FormStep3.tsx
@@ -1,11 +1,11 @@
 import { Button } from "@/components/Button";
 import { Callout } from "@/components/Callout";
-import { Code } from "@/components/Code";
 import { ExternalLink } from "@/components/ExternalLink";
+import { CopyCode } from "@/pageComponents/team/new/tests/CopyCode";
 import { Group } from "@/pageComponents/team/new/tests/Group";
 import { TestRunner } from "@/pageComponents/team/new/tests/constants";
 
-export function FormStep3({
+export default function FormStep3({
   apiKey,
   onBack,
   onContinue,
@@ -53,7 +53,7 @@ function CypressInstructions({ apiKey }: { apiKey: string }) {
     <>
       <div>Now you&apos;re ready to record your tests with Replay!</div>
       <Group>
-        <Code>npx cypress run --browser replay-chromium</Code>
+        <CopyCode code="npx cypress run --browser replay-chromium" />
         <ApiKeyCallout apiKey={apiKey} />
       </Group>
       <CIInstructions href="https://docs.replay.io/test-runners/cypress-io/github-actions" />
@@ -66,7 +66,7 @@ function PlaywrightInstructions({ apiKey }: { apiKey: string }) {
     <>
       <div>Now you&apos;re ready to record your tests with Replay!</div>
       <Group>
-        <Code>npx playwright test --project replay-chromium</Code>
+        <CopyCode code="npx playwright test --project replay-chromium" />
         <ApiKeyCallout apiKey={apiKey} />
       </Group>
       <CIInstructions href="https://docs.replay.io/test-runners/playwright/github-actions" />
@@ -81,7 +81,7 @@ function ApiKeyCallout({ apiKey }: { apiKey: string }) {
         <div className="flex flex-col gap-2">
           <div>If you&apos;ve saved it to an environment variable, you&apos;re all set.</div>
           <div>Otherwise you need to pass it explicitly:</div>
-          <Code className="text-xs">REPLAY_API_KEY={apiKey} npx …</Code>
+          <CopyCode className="text-xs" code={`REPLAY_API_KEY=${apiKey} npx …`} />
         </div>
       }
       headerText="Your API key is needed to upload replays"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,6 +15,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import { MockGraphQLData } from "tests/mocks/types";
 import "use-context-menu/styles.css";
 import "../global.css";
+import "../shiki.css";
 
 type PageProps = {
   accessToken: string;

--- a/src/shiki.css
+++ b/src/shiki.css
@@ -1,0 +1,14 @@
+:root {
+  --shiki-background: inherit;
+  --shiki-color-text: inherit;
+  --shiki-foreground: inherit;
+  --shiki-token-constant: theme("colors.white");
+  --shiki-token-string: theme("colors.green.200");
+  --shiki-token-comment: theme("colors.slate.400");
+  --shiki-token-keyword: theme("colors.sky.300");
+  --shiki-token-parameter: theme("colors.rose.400");
+  --shiki-token-function: theme("colors.purple.400");
+  --shiki-token-string-expression: theme("colors.green.200");
+  --shiki-token-punctuation: theme("colors.slate.400");
+  --shiki-token-link: theme("colors.zinc.700");
+}

--- a/tests/create-test-suites-team-fails.spec.ts
+++ b/tests/create-test-suites-team-fails.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { MockGraphQLData } from "tests/mocks/types";
 import { createApolloError } from "tests/mocks/utils/createApolloError";
-import { getUID } from "tests/mocks/utils/getUID";
 import { mockCreateWorkspaceAPIKey } from "tests/mocks/utils/mockCreateWorkspaceAPIKey";
 import { mockGetUser } from "tests/mocks/utils/mockGetUser";
 import { mockWorkspaceRecordings } from "tests/mocks/utils/mockWorkspaceRecordings";
@@ -17,20 +16,11 @@ test("create-test-suites-team-fails: shows mutation error message", async ({ pag
   const continueButton = page.locator('[data-test-id="CreateTeam-Continue-Button"]');
   const goBackButton = page.locator('[data-test-id="CreateTeam-GoBack-Button"]');
 
-  const multiStepForm = page.locator('[data-test-name="MultiStepForm"]');
-  const step1 = multiStepForm.locator('[data-test-name="MultiStepForm-Step-1"]');
-  const step2 = multiStepForm.locator('[data-test-name="MultiStepForm-Step-2"]');
-  const step3 = multiStepForm.locator('[data-test-name="MultiStepForm-Step-3"]');
-
   await expect(goBackButton).not.toBeVisible();
   await expect(continueButton.isEnabled()).resolves.toBeFalsy();
 
   {
     // Step 1: Team name, test runner, and package manager
-
-    await expect(step1.getAttribute("data-test-state")).resolves.toBe("current");
-    await expect(step2.getAttribute("data-test-state")).resolves.toBe("incomplete");
-    await expect(step3.getAttribute("data-test-state")).resolves.toBe("incomplete");
 
     await page.locator('[data-test-id="CreateTestSuiteTeam-TeamName-Input"]').fill("Example");
     await page
@@ -47,8 +37,6 @@ test("create-test-suites-team-fails: shows mutation error message", async ({ pag
     await expect(error.textContent()).resolves.toContain("Failed to create workspace");
   }
 });
-
-const teamId = getUID("test-suite-team");
 
 const mockGraphQLData: MockGraphQLData = {
   CreateNewWorkspace: {

--- a/tests/utils/waitUntil.ts
+++ b/tests/utils/waitUntil.ts
@@ -1,0 +1,54 @@
+export async function waitUntil(
+  callback: () => Promise<void>,
+  options: {
+    message?: string;
+    retryInterval?: number;
+    timeout?: number;
+  } = {}
+): Promise<void> {
+  const { message, retryInterval = 250, timeout = 2_500 } = options;
+
+  const startTime = performance.now();
+
+  const consoleLog = console.log;
+
+  while (true) {
+    // This loop tries failing code many times before giving up.
+    // It's noisy to log expect() failures on every attempt,
+    // so we suppress them for all but the last attempt.
+    const messages: any[] = [];
+    console.log = (...rest) => messages.push(rest);
+
+    try {
+      await callback();
+
+      return;
+    } catch (error: any) {
+      if (error?.message?.includes("crash")) {
+        // We have to resort to heuristics since:
+        // 1. We don't have access to the `Page` object, and
+        // 2. the Error object also has no special properties.
+        throw error;
+      }
+      if (error?.isUnrecoverable) {
+        // We sometimes don't want to keep trying.
+        throw error;
+      }
+      if (!error?.matcherResult) {
+        // Not an `expect` error: → Log it.
+        console.log("ERROR:", error?.stack || error);
+      }
+
+      if (performance.now() - startTime > timeout) {
+        messages.forEach(args => consoleLog(...args));
+        throw Error(message);
+      }
+
+      await new Promise(resolve => setTimeout(resolve, retryInterval));
+
+      continue;
+    } finally {
+      console.log = consoleLog;
+    }
+  }
+}


### PR DESCRIPTION
- [x] Add Shiki for syntax highlighting and update `Code` and `CopyCode` components to use it
- [x] Generate API key on server side to avoid potential hydration mismatch warning (just noticed it while I was in there)
  - We should probably land this change regardless of whether this PR lands
- [x] Lazy load test suite team forms
  - We should probably land this change regardless of whether this PR lands
- ~~Pre-generate HTML for syntax highlighting on the server only~~
  - I lazy-load this code instead; I think that's sufficient for now.

![Screenshot 2024-05-21 at 8 41 57 AM](https://github.com/replayio/dashboard/assets/29597/1f34bf75-2402-421d-b7fc-ee6b68d5e333)
