### PR TITLE
Re-organize Test Suites API key instructions

### DIFF
--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -1,0 +1,44 @@
+import { Icon, IconType } from "@/components/Icon";
+import { ReactNode } from "react";
+
+type Type = "error" | "info" | "warning";
+
+export function Callout({
+  bodyText,
+  headerText,
+  type,
+}: {
+  bodyText: ReactNode;
+  headerText: ReactNode;
+  type: Type;
+}) {
+  let className: string;
+  let iconType: IconType;
+  switch (type) {
+    case "error":
+      className = "text-red-500";
+      iconType = "error";
+      break;
+    case "info":
+      className = "text-sky-500";
+      iconType = "info";
+      break;
+    case "warning":
+      className = "text-yellow-400";
+      iconType = "warning";
+      break;
+  }
+
+  return (
+    <div className="flex flex-col rounded-md px-3 py-2 bg-slate-800">
+      <div className={`flex flex-row items-center gap-2 font-bold ${className}`}>
+        <Icon className="w-5 h-5" type={iconType} />
+        {headerText}
+      </div>
+      <div className="flex flex-row items-center gap-2 text-slate-300 text-sm">
+        <div className="w-5 h-5"></div>
+        {bodyText}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -19,10 +19,12 @@ export type IconType =
   | "drop-down-caret-left"
   | "edit"
   | "email"
+  | "error"
   | "external-link"
   | "failed-test"
   | "flaky-test"
   | "folder"
+  | "help"
   | "home"
   | "info"
   | "legal"
@@ -129,6 +131,10 @@ export function Icon({
       path =
         "M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z";
       break;
+    case "error":
+      path =
+        "M4.47 21h15.06c1.54 0 2.5-1.67 1.73-3L13.73 4.99c-.77-1.33-2.69-1.33-3.46 0L2.74 18c-.77 1.33.19 3 1.73 3zM12 14c-.55 0-1-.45-1-1v-2c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1zm1 4h-2v-2h2v2z";
+      break;
     case "external-link":
       path =
         "M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z";
@@ -144,6 +150,10 @@ export function Icon({
     case "folder":
       path =
         "M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z";
+      break;
+    case "help":
+      path =
+        "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z";
       break;
     case "home":
       path = (

--- a/src/pageComponents/team/new/tests/CopyCode.tsx
+++ b/src/pageComponents/team/new/tests/CopyCode.tsx
@@ -44,10 +44,10 @@ export function CopyCode({ text }: { text: string }) {
       onMouseEnter={onMouse}
       onMouseLeave={onMouse}
     >
-      <Code className="w-full hover:text-blue-400 cursor-pointer">{text}</Code>
+      <Code className="w-full hover:text-sky-400 cursor-pointer">{text}</Code>
       <div className="absolute top-1 right-1 pointer-events-none flex flex-row items-center text-xs">
         {state === "copied" ? (
-          <span className="bg-slate-950 px-1 round text-blue-400">Copied</span>
+          <span className="bg-slate-950 px-1 round text-sky-400">Copied</span>
         ) : state === "hover" ? (
           <div className="bg-slate-950 px-1 round">Copy</div>
         ) : (

--- a/src/pageComponents/team/new/tests/CreateTestSuitesTeam.tsx
+++ b/src/pageComponents/team/new/tests/CreateTestSuitesTeam.tsx
@@ -149,12 +149,12 @@ export function CreateTestSuitesTeam() {
     case 3: {
       form = (
         <FormStep3
+          apiKey={state.apiKey}
           onContinue={() => {
             assert(state.step === 3);
 
             router.push(`/team/${state.workspaceId}`);
           }}
-          packageManager={state.packageManager}
           testRunner={state.testRunner}
         />
       );
@@ -165,7 +165,7 @@ export function CreateTestSuitesTeam() {
   return (
     <div className="flex flex-row h-screen w-screen" data-test-id="CreateTestSuitesTeam">
       <div className="grow flex flex-row justify-center w-full overflow-auto p-8">
-        <div className="flex flex-col center-items gap-6 w-[535px]">
+        <div className="flex flex-col center-items gap-6 w-[505px]">
           <Link className="flex flex-row items-center text-xl text-white" href="/home">
             <Icon className="w-4 h-4" type="back-arrow" /> Back to library
           </Link>

--- a/src/pageComponents/team/new/tests/FormStep2.tsx
+++ b/src/pageComponents/team/new/tests/FormStep2.tsx
@@ -1,10 +1,12 @@
 import { Button } from "@/components/Button";
+import { Callout } from "@/components/Callout";
 import { Code } from "@/components/Code";
+import { ExternalLink } from "@/components/ExternalLink";
 import { CopyCode } from "@/pageComponents/team/new/tests/CopyCode";
 import { Group } from "@/pageComponents/team/new/tests/Group";
 import { PackageManager, TestRunner } from "@/pageComponents/team/new/tests/constants";
 import { getInstallCommand } from "@/pageComponents/team/new/tests/getInstallCommand";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 export function FormStep2({
   apiKey,
@@ -57,23 +59,17 @@ export function CypressInstructions({
   return (
     <>
       <Group>
-        <div>1. Install the @replayio/cypress package in your project</div>
+        <div>1. Install the @replayio/cypress package in your project.</div>
         <Code>{getInstallCommand(packageManager, "@replayio/cypress", { development: true })}</Code>
       </Group>
       <Group>
         <div>2. Add the Replay browser and Reporter to your cypress.config.ts file.</div>
         <Code>{cypressConfigCode}</Code>
       </Group>
+      <SaveApiKey apiKey={apiKey} number={3} />
       <Group>
-        <div>3. Import Replay to your support file</div>
+        <div>4. Import Replay to your support file.</div>
         <Code>{`require('@replayio/cypress/support');`}</Code>
-      </Group>
-      <Group>
-        <div>
-          4. Copy this API key to your .env file;{" "}
-          <strong className="text-yellow-400">(it will only be shown once!)</strong>
-        </div>
-        <CopyCode text={`REPLAY_API_KEY=${apiKey}`} />
       </Group>
     </>
   );
@@ -89,23 +85,39 @@ export function PlaywrightInstructions({
   return (
     <>
       <Group>
-        <div>1. Install the @replayio/playwright package in your project</div>
+        <div>1. Install the @replayio/playwright package in your project.</div>
         <Code>
           {getInstallCommand(packageManager, "@replayio/playwright", { development: true })}
         </Code>
       </Group>
+      <SaveApiKey apiKey={apiKey} number={2} />
       <Group>
-        <div>2. Add the Replay browser and Reporter to your playwright.config.ts file.</div>
+        <div>3. Add the Replay browser and Reporter to your playwright.config.ts file.</div>
         <Code>{playwrightConfigCode}</Code>
       </Group>
-      <Group>
-        <div>
-          3. Copy this API key to your .env file;{" "}
-          <strong className="text-yellow-400">(it will only be shown once!)</strong>
-        </div>
-        <CopyCode text={`REPLAY_API_KEY=${apiKey}`} />
-      </Group>
     </>
+  );
+}
+
+function SaveApiKey({ apiKey, number }: { apiKey: string; number: number }) {
+  return (
+    <Group>
+      <div>{number}. Save the API key below before continuing.</div>
+      <CopyCode text={`REPLAY_API_KEY=${apiKey}`} />
+      <Callout
+        bodyText={
+          <div>
+            We&apos;ll only show it once. See our{" "}
+            <ExternalLink href="https://docs.replay.io/ci-workflows/generate-api-key#using-your-api-key">
+              &quot;Getting Started&quot; docs
+            </ExternalLink>{" "}
+            for more info.
+          </div>
+        }
+        headerText="Save the API key before continuing!"
+        type="warning"
+      />
+    </Group>
   );
 }
 
@@ -145,5 +157,6 @@ const config: PlaywrightTestConfig = {
     }
   ],
 };
+
 export default config;
 `.trim();

--- a/src/pageComponents/team/new/tests/FormStep3.tsx
+++ b/src/pageComponents/team/new/tests/FormStep3.tsx
@@ -1,25 +1,27 @@
 import { Button } from "@/components/Button";
+import { Callout } from "@/components/Callout";
 import { Code } from "@/components/Code";
+import { ExternalLink } from "@/components/ExternalLink";
 import { Group } from "@/pageComponents/team/new/tests/Group";
-import { PackageManager, TestRunner } from "@/pageComponents/team/new/tests/constants";
+import { TestRunner } from "@/pageComponents/team/new/tests/constants";
 
 export function FormStep3({
+  apiKey,
   onContinue,
-  packageManager,
   testRunner,
 }: {
+  apiKey: string;
   onContinue: () => void;
-  packageManager: PackageManager;
   testRunner: TestRunner;
 }) {
   let instructions;
   switch (testRunner) {
     case "cypress": {
-      instructions = <CypressInstructions />;
+      instructions = <CypressInstructions apiKey={apiKey} />;
       break;
     }
     case "playwright": {
-      instructions = <PlaywrightInstructions />;
+      instructions = <PlaywrightInstructions apiKey={apiKey} />;
       break;
     }
   }
@@ -39,20 +41,38 @@ export function FormStep3({
   );
 }
 
-export function CypressInstructions() {
+export function CypressInstructions({ apiKey }: { apiKey: string }) {
   return (
     <Group>
       <strong>5. Run cypress as you normally would</strong>
       <Code>npx cypress run --browser replay-chromium</Code>
+      <ApiKeyCallout apiKey={apiKey} />
     </Group>
   );
 }
 
-export function PlaywrightInstructions() {
+export function PlaywrightInstructions({ apiKey }: { apiKey: string }) {
   return (
     <Group>
       <strong>4. Run playwright as you normally would</strong>
       <Code>npx playwright test --project replay-chromium</Code>
+      <ApiKeyCallout apiKey={apiKey} />
     </Group>
+  );
+}
+
+export function ApiKeyCallout({ apiKey }: { apiKey: string }) {
+  return (
+    <Callout
+      bodyText={
+        <div className="flex flex-col gap-2">
+          <div>If you&apos;ve saved it to an environment variable, you&apos;re all set.</div>
+          <div>Otherwise you need to pass it explicitly:</div>
+          <Code className="text-xs">REPLAY_API_KEY={apiKey} npx …</Code>
+        </div>
+      }
+      headerText="Your API key is needed to upload replays"
+      type="info"
+    />
   );
 }


### PR DESCRIPTION
- [x] Put the `API_KEY` copy instructions _before_ the config instructions
- [x] Add more help about how to save (and use) the API key

![Screenshot 2024-05-21 at 5 44 42 PM](https://github.com/replayio/dashboard/assets/29597/2c9e3b62-7a24-4f0b-8c42-af1182941488)

![Screenshot 2024-05-21 at 5 51 31 PM](https://github.com/replayio/dashboard/assets/29597/a200bae0-fd56-4a26-be78-369608746b44)

cc @jonbell-lot23, @filiphric 