### PR TITLE
Default new team instructions to playwright

### DIFF
--- a/src/pageComponents/team/new/tests/constants.ts
+++ b/src/pageComponents/team/new/tests/constants.ts
@@ -12,7 +12,7 @@ const Playwright: TestRunnerOption = {
   label: "Playwright",
   type: "playwright",
 };
-export const TEST_RUNNER_OPTIONS: TestRunnerOption[] = [Playwright, Cypress];
+export const TEST_RUNNER_OPTIONS: TestRunnerOption[] = [Cypress, Playwright];
 
 export type PackageManager = "npm" | "pnpm" | "yarn";
 export type PackageManagerOption = Option & {


### PR DESCRIPTION
**Rationale**

Some things can't be auto-filled, like team name. But other things can go with the principle of "reasonable defaults." Without doing this, we require 100% of people to take an action. But by doing this, some percent won't have to take an action, and the other folks (Cypress users) do, which is no worse than before.

Even if playwright and cypress were 50%, reasonable defaults are still good. But in this case, I think playwright should be higher in the list and default.

I did the same thing for npm for the same reason. Even if that means 66% of people have to take an action, that's still better than 100% taking an action.

Old:
<img width="557" alt="image" src="https://github.com/replayio/dashboard/assets/9154902/5356c101-ced0-4493-81bf-cead76e3a730">

New:
<img width="569" alt="image" src="https://github.com/replayio/dashboard/assets/9154902/f29d82c0-4d99-4eeb-a637-c81b696f9482">
