### PR TITLE
Don't show API Keys page to user/viewer role

### DIFF
--- a/src/pageComponents/team/id/settings/WorkspaceSettings.tsx
+++ b/src/pageComponents/team/id/settings/WorkspaceSettings.tsx
@@ -1,10 +1,13 @@
+import { SessionContext } from "@/components/SessionContext";
+import { useGetWorkspaceMembers } from "@/graphql/queries/getWorkspaceMembers";
 import { Workspace } from "@/graphql/types";
 import { Billing } from "@/pageComponents/team/id/settings/Billing";
 import { DeleteWorkspace } from "@/pageComponents/team/id/settings/DeleteWorkspace";
 import { Organization } from "@/pageComponents/team/id/settings/Organization";
 import { TeamMembers } from "@/pageComponents/team/id/settings/TeamMembers";
 import { WorkspaceApiKeys } from "@/pageComponents/team/id/settings/WorkspaceApiKeys";
-import { ReactNode } from "react";
+import { useRouter } from "next/router";
+import { ReactNode, useContext, useEffect } from "react";
 
 export function WorkspaceSettings({
   route,
@@ -15,31 +18,54 @@ export function WorkspaceSettings({
   stripeKey: string;
   workspace: Workspace;
 }) {
+  const workspaceId = workspace.id;
+
+  const { user } = useContext(SessionContext);
+
+  const router = useRouter();
+
+  const { members } = useGetWorkspaceMembers(workspaceId);
+
+  const member = members?.find(({ id }) => id === user?.id);
+
+  const currentUserIsAdmin = member?.roles.includes("admin") == true;
+  const currentUserIsDeveloper = member?.roles.includes("debugger") == true;
+
   let content: ReactNode = null;
   switch (route) {
     case "api-keys": {
-      content = <WorkspaceApiKeys workspaceId={workspace.id} />;
+      if (currentUserIsAdmin || currentUserIsDeveloper) {
+        content = <WorkspaceApiKeys workspaceId={workspaceId} />;
+      }
       break;
     }
     case "billing": {
-      content = <Billing stripeKey={stripeKey} workspaceId={workspace.id} />;
+      if (currentUserIsAdmin) {
+        content = <Billing stripeKey={stripeKey} workspaceId={workspaceId} />;
+      }
       break;
     }
     case "delete": {
-      content = <DeleteWorkspace workspaceId={workspace.id} />;
+      if (currentUserIsAdmin) {
+        content = <DeleteWorkspace workspaceId={workspaceId} />;
+      }
       break;
     }
     case "members": {
-      content = (
-        <TeamMembers workspaceId={workspace.id} invitationCode={workspace.invitationCode} />
-      );
+      content = <TeamMembers workspaceId={workspaceId} invitationCode={workspace.invitationCode} />;
       break;
     }
     case "organization": {
-      content = <Organization workspaceId={workspace.id} />;
+      content = <Organization workspaceId={workspaceId} />;
       break;
     }
   }
+
+  useEffect(() => {
+    if (content === null) {
+      router.replace(`/team/${workspaceId}/settings/members`);
+    }
+  }, [content, router, workspaceId]);
 
   return <div className="h-full w-full overflow-auto bg-slate-800 p-2 rounded">{content}</div>;
 }

--- a/src/pageComponents/team/id/settings/layout/TeamSettingsNav.tsx
+++ b/src/pageComponents/team/id/settings/layout/TeamSettingsNav.tsx
@@ -27,6 +27,7 @@ export function TeamSettingsNav() {
   }
 
   const currentUserIsAdmin = member?.roles.includes("admin") == true;
+  const currentUserIsDeveloper = member?.roles.includes("debugger") == true;
 
   return (
     <LeftNav
@@ -57,12 +58,14 @@ export function TeamSettingsNav() {
           iconType="billing"
         />
       )}
-      <TeamSettingsNavLink
-        workspaceId={workspace.id}
-        label="API keys"
-        route="api-keys"
-        iconType="api-keys"
-      />
+      {(currentUserIsAdmin || currentUserIsDeveloper) && (
+        <TeamSettingsNavLink
+          workspaceId={workspace.id}
+          label="API keys"
+          route="api-keys"
+          iconType="api-keys"
+        />
+      )}
       {currentUserIsAdmin && (
         <TeamSettingsNavLink
           workspaceId={workspace.id}

--- a/tests/mocks/utils/mockGetWorkspaces.ts
+++ b/tests/mocks/utils/mockGetWorkspaces.ts
@@ -23,7 +23,7 @@ export function mockGetWorkspaces(
               invitationCode: workspace.invitationCode ?? "11111111-2222-3333-4444-55555555",
               isOrganization: workspace.isOrganization ?? false,
               isTest: workspace.isTest ?? false,
-              name: workspace.name ?? "Fake Worksapce",
+              name: workspace.name ?? "Fake Workspace",
               settings: workspace.settings
                 ? {
                     __typename: "WorkspaceSettings",

--- a/tests/team-settings-billing-subscription-active-no-card.spec.ts
+++ b/tests/team-settings-billing-subscription-active-no-card.spec.ts
@@ -1,8 +1,9 @@
 import { getRelativeDate } from "@/utils/date";
 import { expect, test } from "@playwright/test";
-import { mockGetWorkspaces } from "tests/mocks/utils/mockGetWorkspaces";
 import { mockGetUser } from "tests/mocks/utils/mockGetUser";
+import { mockGetWorkspaceMembers } from "tests/mocks/utils/mockGetWorkspaceMembers";
 import { mockGetWorkspaceSubscription } from "tests/mocks/utils/mockGetWorkspaceSubscription";
+import { mockGetWorkspaces } from "tests/mocks/utils/mockGetWorkspaces";
 import { DEFAULT_WORKSPACE_ID } from "./mocks/constants";
 import { MockGraphQLData } from "./mocks/types";
 import { navigateToPage } from "./utils/navigateToPage";
@@ -30,8 +31,16 @@ test("team-settings-billing-subscription-active-no-card: should show option to a
   await expect(button).toBeVisible();
 });
 
+const mockWorkspaceMembers = mockGetWorkspaceMembers([
+  {
+    roles: ["admin"],
+  },
+]);
+
 const mockGraphQLData: MockGraphQLData = {
   GetUser: mockGetUser(),
+  GetWorkspaceMembers: mockWorkspaceMembers,
+  GetWorkspaceMemberRoles: mockWorkspaceMembers,
   GetWorkspaces: mockGetWorkspaces([
     {
       hasPaymentMethod: false,

--- a/tests/team-settings-billing-subscription-active.spec.ts
+++ b/tests/team-settings-billing-subscription-active.spec.ts
@@ -1,8 +1,9 @@
 import { getRelativeDate } from "@/utils/date";
 import { expect, test } from "@playwright/test";
-import { mockGetWorkspaces } from "tests/mocks/utils/mockGetWorkspaces";
 import { mockGetUser } from "tests/mocks/utils/mockGetUser";
+import { mockGetWorkspaceMembers } from "tests/mocks/utils/mockGetWorkspaceMembers";
 import { mockGetWorkspaceSubscription } from "tests/mocks/utils/mockGetWorkspaceSubscription";
+import { mockGetWorkspaces } from "tests/mocks/utils/mockGetWorkspaces";
 import { DEFAULT_WORKSPACE_ID } from "./mocks/constants";
 import { MockGraphQLData } from "./mocks/types";
 import { navigateToPage } from "./utils/navigateToPage";
@@ -35,8 +36,16 @@ test("team-settings-billing-subscription-active: should show information about t
   await expect(dialog).toContainText("Remove payment method");
 });
 
+const mockWorkspaceMembers = mockGetWorkspaceMembers([
+  {
+    roles: ["admin"],
+  },
+]);
+
 const mockGraphQLData: MockGraphQLData = {
   GetUser: mockGetUser(),
+  GetWorkspaceMembers: mockWorkspaceMembers,
+  GetWorkspaceMemberRoles: mockWorkspaceMembers,
   GetWorkspaces: mockGetWorkspaces([
     {
       hasPaymentMethod: true,

--- a/tests/team-settings-protected-routes.spec.ts
+++ b/tests/team-settings-protected-routes.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+import { mockGetUser } from "tests/mocks/utils/mockGetUser";
+import { mockGetWorkspaceMembers } from "tests/mocks/utils/mockGetWorkspaceMembers";
+import { mockGetWorkspaceSubscription } from "tests/mocks/utils/mockGetWorkspaceSubscription";
+import { mockGetWorkspaces } from "tests/mocks/utils/mockGetWorkspaces";
+import { DEFAULT_WORKSPACE_ID } from "./mocks/constants";
+import { MockGraphQLData } from "./mocks/types";
+import { navigateToPage } from "./utils/navigateToPage";
+
+test("team-settings-protected-routes: should restrict certain routes from non-developer or non-admin roles", async ({
+  page,
+}) => {
+  await navigateToPage({
+    mockGraphQLData,
+    page,
+    pathname: `/team/${DEFAULT_WORKSPACE_ID}/settings/members`,
+  });
+
+  // Protected routes should not be in the left nav
+
+  const links = page.locator('[data-test-name="LeftNavLink"]');
+  await expect(links).toHaveCount(3);
+  await expect(links.allTextContents()).resolves.toContain("Home");
+  await expect(links.allTextContents()).resolves.toContain("My Library");
+  await expect(links.allTextContents()).resolves.toContain("Members");
+
+  // Protected routes should not be accessible if directly loaded
+
+  const activeLink = page.locator('[data-test-name="LeftNavLink"][data-is-active="true"]');
+
+  await navigateToPage({
+    mockGraphQLData,
+    page,
+    pathname: `/team/${DEFAULT_WORKSPACE_ID}/settings/api-keys`,
+  });
+  await expect(activeLink).toContainText("Members");
+
+  await navigateToPage({
+    mockGraphQLData,
+    page,
+    pathname: `/team/${DEFAULT_WORKSPACE_ID}/settings/delete`,
+  });
+  await expect(activeLink).toContainText("Members");
+
+  await navigateToPage({
+    mockGraphQLData,
+    page,
+    pathname: `/team/${DEFAULT_WORKSPACE_ID}/settings/delete`,
+  });
+  await expect(activeLink).toContainText("Members");
+});
+
+const mockWorkspaceMembers = mockGetWorkspaceMembers([
+  {
+    roles: ["viewer"],
+  },
+]);
+
+const mockGraphQLData: MockGraphQLData = {
+  GetUser: mockGetUser(),
+  GetWorkspaceMembers: mockWorkspaceMembers,
+  GetWorkspaceMemberRoles: mockWorkspaceMembers,
+  GetWorkspaces: mockGetWorkspaces([{}]),
+  GetWorkspaceSubscription: mockGetWorkspaceSubscription({}),
+};


### PR DESCRIPTION
- [x] Don't show API keys route to "viewer" roles
- [x] Explicitly redirect routes a user doesn't have access to back to the members settings route
- [x] Add e2e test for the above two changes