### PR TITLE
Eliminate flake in `create-test-suites-team-fails`

### DIFF
--- a/src/hooks/useGraphQLMutation.ts
+++ b/src/hooks/useGraphQLMutation.ts
@@ -31,6 +31,10 @@ export function useGraphQLMutation<Query, Variables extends OperationVariables =
   });
 
   // Support e2e tests
+  // WARNING: this doesn't quite mimick the real user flow
+  // usually the data/error would get returned asynchronously when the mutations happens
+  // we are returning it here synchronously so the initial HTML comes "preresolved"
+  // so it can be different from the one that would be returned in equivalen scenario in production
   const mockResponse = mockGraphQLData ? getMockGraphQLResponse(mockGraphQLData, query) : undefined;
   if (mockResponse) {
     const mutate: MutationFunction<Query, Variables> = async () => {

--- a/tests/create-test-suites-team-fails.spec.ts
+++ b/tests/create-test-suites-team-fails.spec.ts
@@ -19,23 +19,9 @@ test("create-test-suites-team-fails: shows mutation error message", async ({ pag
   await expect(goBackButton).not.toBeVisible();
   await expect(continueButton.isEnabled()).resolves.toBeFalsy();
 
-  {
-    // Step 1: Team name, test runner, and package manager
-
-    await page.locator('[data-test-id="CreateTestSuiteTeam-TeamName-Input"]').fill("Example");
-    await page
-      .locator('[data-test-id="CreateTestSuiteTeam-TestRunner-Select"]')
-      .selectOption({ label: "Playwright" });
-    await page
-      .locator('[data-test-id="CreateTestSuiteTeam-PackageManager-Select"]')
-      .selectOption({ label: "pnpm" });
-
-    await expect(continueButton.isEnabled()).resolves.toBeTruthy();
-    await continueButton.click();
-
-    const error = page.locator('[data-test-id="CreateTeam-Error"]');
-    await expect(error.textContent()).resolves.toContain("Failed to create workspace");
-  }
+  // test error synchronously returned by the mutation mock
+  const error = page.locator('[data-test-id="CreateTeam-Error"]');
+  await expect(error.textContent()).resolves.toContain("Failed to create workspace");
 });
 
 const mockGraphQLData: MockGraphQLData = {


### PR DESCRIPTION
[Passing recording](https://app.replay.io/recording/create-test-suites-team-fails-shows-mutation-error-message--218ba0c4-74f0-4ddd-ae6d-4af47d8e44ef?commentId=&focusWindow=eyJiZWdpbiI6eyJwb2ludCI6IjAiLCJ0aW1lIjowfSwiZW5kIjp7InBvaW50IjoiMjkyMDY2Njk4Mjk4NzE2NDQzNTg3ODQ0MjM3NTgzOTc0NCIsInRpbWUiOjkyN319&point=1622592768318661204815248980180994&primaryPanel=comments&secondaryPanel=console&time=597.96849180787&viewMode=dev)
[Failing recording](https://app.replay.io/recording/create-test-suites-team-fails-shows-mutation-error-message--76dd5568-8e6a-45a8-b18e-b439b9a6d637?commentId=&focusWindow=eyJiZWdpbiI6eyJwb2ludCI6IjAiLCJ0aW1lIjowfSwiZW5kIjp7InBvaW50IjoiMTk0NzExMTMyMTk4NjkyMzUwNDk1NDIzNjA3NzA4MDg4OSIsInRpbWUiOjY4M319&point=649037107331191185397263487729678&primaryPanel=debugger&secondaryPanel=network&time=297.9942800298433&viewMode=dev)

The test is currently flaky because our FormStep components are loaded lazily and the mocked mutations are preresolved synchronously on the server. This creates a race condition - an interaction within the server-served component (that is lazy-loaded on the client) can't be executed before the corresponding code chunk gets downloaded and executed.

The test managed to execute actions before the chunk was downloaded. After that, it immediately asserted on the UI state that was meant to get changed and failed on that.