### PR TITLE
Improve test setup form copy command

### DIFF
--- a/src/pageComponents/team/new/tests/FormStep3.tsx
+++ b/src/pageComponents/team/new/tests/FormStep3.tsx
@@ -49,12 +49,14 @@ export default function FormStep3({
 }
 
 function CypressInstructions({ apiKey }: { apiKey: string }) {
+  const code = "npx cypress run --browser replay-chromium";
+
   return (
     <>
       <div>Now you&apos;re ready to record your tests with Replay!</div>
       <Group>
-        <CopyCode code="npx cypress run --browser replay-chromium" />
-        <ApiKeyCallout apiKey={apiKey} />
+        <CopyCode code={code} />
+        <ApiKeyCallout apiKey={apiKey} code={code} />
       </Group>
       <CIInstructions href="https://docs.replay.io/test-runners/cypress-io/github-actions" />
     </>
@@ -62,26 +64,32 @@ function CypressInstructions({ apiKey }: { apiKey: string }) {
 }
 
 function PlaywrightInstructions({ apiKey }: { apiKey: string }) {
+  const code = "npx playwright test --project replay-chromium";
+
   return (
     <>
       <div>Now you&apos;re ready to record your tests with Replay!</div>
       <Group>
-        <CopyCode code="npx playwright test --project replay-chromium" />
-        <ApiKeyCallout apiKey={apiKey} />
+        <CopyCode code={code} />
+        <ApiKeyCallout apiKey={apiKey} code={code} />
       </Group>
       <CIInstructions href="https://docs.replay.io/test-runners/playwright/github-actions" />
     </>
   );
 }
 
-function ApiKeyCallout({ apiKey }: { apiKey: string }) {
+function ApiKeyCallout({ apiKey, code }: { apiKey: string; code: string }) {
   return (
     <Callout
       bodyText={
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 grow">
           <div>If you&apos;ve saved it to an environment variable, you&apos;re all set.</div>
           <div>Otherwise you need to pass it explicitly:</div>
-          <CopyCode className="text-xs" code={`REPLAY_API_KEY=${apiKey} npx …`} />
+          <CopyCode
+            code={`REPLAY_API_KEY=${apiKey} npx …`}
+            codeToCopy={`REPLAY_API_KEY=${apiKey} ${code}`}
+            size="small"
+          />
         </div>
       }
       headerText="Your API key is needed to upload replays"

--- a/src/pageComponents/team/new/tests/components/CopyCode.tsx
+++ b/src/pageComponents/team/new/tests/components/CopyCode.tsx
@@ -7,11 +7,15 @@ import type { BundledLanguage } from "shiki";
 export function CopyCode({
   className,
   code,
+  codeToCopy,
   lang,
+  size = "normal",
 }: {
   className?: string;
   code: string;
+  codeToCopy?: string;
   lang?: BundledLanguage;
+  size?: "normal" | "small";
 }) {
   const [state, setState] = useState<"hover" | "copied" | undefined>();
 
@@ -28,7 +32,7 @@ export function CopyCode({
         setState(undefined);
         break;
       case "click":
-        copyText(code);
+        copyText(codeToCopy ?? code);
         setState("copied");
         break;
     }
@@ -47,13 +51,17 @@ export function CopyCode({
 
   return (
     <div
-      className="flex relative"
+      className="flex relative shrink-0"
       data-test-name="CopyCode"
       onClick={onMouse}
       onMouseEnter={onMouse}
       onMouseLeave={onMouse}
     >
-      <Code className={`w-full cursor-pointer ${className}`} code={code} lang={lang} />
+      <Code
+        className={`w-full cursor-pointer ${size === "normal" ? "" : "text-xs"} ${className}`}
+        code={code}
+        lang={lang}
+      />
       <div className="absolute top-1 right-0 pointer-events-none flex flex-row items-center text-xs">
         {state === "copied" ? (
           <span className="bg-slate-950 px-1 round text-sky-400">Copied</span>
@@ -61,7 +69,7 @@ export function CopyCode({
           <div className="bg-slate-950 px-1 round">Copy</div>
         ) : (
           <div className="bg-slate-950 px-1 round">
-            <Icon className="w-5 h-5" type="copy" />
+            <Icon className={size === "normal" ? "w-5 h-5" : "w-4 h-4"} type="copy" />
           </div>
         )}
       </div>


### PR DESCRIPTION
### Note I am on PTO until Monday the 3rd; feel free to merge this without me if this is approved.

---

Based on @miriambudayr's feedback, even though we show a truncated npx command, we'll now copy the full command (including the API key)

### Before
![Screenshot 2024-05-30 at 3 50 39 PM](https://github.com/replayio/dashboard/assets/29597/b5b2ef3e-43d4-4218-9e8f-aa9015875566)

### After
![Screenshot 2024-05-30 at 3 50 44 PM](https://github.com/replayio/dashboard/assets/29597/43ea1e4f-0c05-4918-bbf7-fe49a7e7b13d)

I also fixed a minor CSS sizing bug
