### PR TITLE
Clear `defaultPathname` cookie on logout

### DIFF
--- a/src/pageComponents/user/settings/Account.tsx
+++ b/src/pageComponents/user/settings/Account.tsx
@@ -14,6 +14,7 @@ export function Account() {
     setIsPending(true);
 
     setAccessTokenInBrowserPrefs(null);
+    deleteCookieValueClient(COOKIES.defaultPathname);
     deleteCookieValueClient(COOKIES.accessToken);
 
     window.location.replace(`/api/auth/logout?${new URLSearchParams({ origin: location.origin })}`);


### PR DESCRIPTION
When switching between accounts this cookie currently leads to an annoying scenario:
1. user A visits workspace W
2. user A logs out
3. user B logs in
4. they get redirected to workspace W but they might not have permission to view it, they hit the 404 page