### PR TITLE
Deprioritize `groupLabel`

### DIFF
--- a/src/utils/test-suites.ts
+++ b/src/utils/test-suites.ts
@@ -147,12 +147,18 @@ export function isPlanPricingPerSeat(subscription: WorkspaceSubscription) {
 
 export function getTestRunTitle(groupedTestCases: TestRun): string {
   const { commitTitle, groupLabel, prTitle } = groupedTestCases;
-  if (groupLabel) {
-    return groupLabel;
-  } else if (commitTitle) {
+  if (commitTitle) {
     return commitTitle;
   } else if (prTitle) {
     return prTitle;
+  } else if (groupLabel) {
+    // it feels like this should have the highest priority
+    // however, REPLAY_METADATA_TEST_RUN_TITLE is sometimes used to set this
+    // we need to investigate how it gets used and why to raise priority here
+    // and to suggests other solutions to customers if needed
+    //
+    // if this gets the highest priority, then all test runs from different branches are displayed using the same title
+    return groupLabel;
   }
 
   return "Test";


### PR DESCRIPTION
see https://discord.com/channels/779097926135054346/1251166940949381121/1251167101981294674

we can confirm here that it works OK with this change: https://dashboard-mz33bk1kx-replayio.vercel.app/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs