### PR TITLE
Revert "Temporarily disable tests view"

### DIFF
--- a/src/components/LeftNavLink.tsx
+++ b/src/components/LeftNavLink.tsx
@@ -4,20 +4,18 @@ import Link from "next/link";
 import { HTMLAttributes, ReactNode } from "react";
 
 export function LeftNavLink({
-  disabled,
   href,
   iconType,
   isActive,
   label,
   ...rest
 }: HTMLAttributes<HTMLElement> & {
-  disabled?: boolean;
   href: string;
   iconType: IconType;
   isActive: boolean;
   label: ReactNode;
 }) {
-  const Component = disabled || isActive ? "div" : Link;
+  const Component = isActive ? "div" : Link;
 
   // Scroll into view on mount
   useIsomorphicLayoutEffect(() => {
@@ -33,7 +31,7 @@ export function LeftNavLink({
     <Component
       className={`flex flex-row gap-2 items-center text-white px-2 py-1 transition rounded ${
         isActive ? "bg-sky-900 cursor-default" : "hover:text-sky-500"
-      } ${disabled ? "opacity-50 cursor-default hover:text-white" : ""}`}
+      }`}
       data-is-active={isActive || undefined}
       data-test-name="LeftNavLink"
       href={href}

--- a/src/pageComponents/team/layout/TeamNav.tsx
+++ b/src/pageComponents/team/layout/TeamNav.tsx
@@ -37,14 +37,11 @@ export function TeamNav() {
             isActive={!!pathname?.endsWith("runs")}
             label="Runs"
           />
-          {/* TODO [PRO-664] Re-enable Tests view once GraphQL perf issue has been resolved */}
           <LeftNavLink
-            disabled
             href={`/team/${workspace.id}/tests`}
             iconType="menu-tests"
             isActive={!!pathname?.endsWith("tests")}
             label="Tests"
-            title="Tests view is temporarily disabled while we fix an performance issue."
           />
         </>
       ) : (

--- a/src/pages/team/[id]/tests.tsx
+++ b/src/pages/team/[id]/tests.tsx
@@ -1,6 +1,3 @@
-import { Button } from "@/components/Button";
-import { EmptyLayout } from "@/components/EmptyLayout";
-import { Message } from "@/components/Message";
 import { COOKIES } from "@/constants";
 import { useSyncDefaultWorkspace } from "@/hooks/useSyncDefaultWorkspace";
 import { getServerSideWorkspaceProps } from "@/pageComponents/team/id/getServerSidePropsHelpers";
@@ -9,7 +6,6 @@ import { ContextRoot, Filters } from "@/pageComponents/team/id/tests/TestsViewCo
 import { TeamLayout } from "@/pageComponents/team/layout/TeamLayout";
 import { redirectWithState } from "@/utils/redirectWithState";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
-import { useRouter } from "next/navigation";
 
 export default function Page({
   filters,
@@ -19,37 +15,19 @@ export default function Page({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   useSyncDefaultWorkspace();
 
-  // TODO [PRO-664] Re-enable Tests view once GraphQL perf issue has been resolved
-  const router = useRouter();
   return (
-    <Message className="m-4">
-      <div>Tests view is temporarily disabled while we fix an performance issue.</div>
-      <Button
-        onClick={() => {
-          router.push("/home");
-        }}
-        size="large"
-      >
-        Go home
-      </Button>
-    </Message>
+    <ContextRoot
+      defaultTestSummaryId={testSummaryId}
+      filters={filters}
+      retentionLimit={retentionLimit}
+      workspaceId={workspaceId}
+    >
+      <TestSuiteTestsPage />
+    </ContextRoot>
   );
-
-  // return (
-  //   <ContextRoot
-  //     defaultTestSummaryId={testSummaryId}
-  //     filters={filters}
-  //     retentionLimit={retentionLimit}
-  //     workspaceId={workspaceId}
-  //   >
-  //     <TestSuiteTestsPage />
-  //   </ContextRoot>
-  // );
 }
 
-// TODO [PRO-664]
-// Page.Layout = TeamLayout;
-Page.Layout = EmptyLayout;
+Page.Layout = TeamLayout;
 
 export async function getServerSideProps(context: GetServerSidePropsContext<any>) {
   const stringValue = context.req.cookies[COOKIES.testsFilters];

--- a/tests/test-suites-tests-1.spec.ts
+++ b/tests/test-suites-tests-1.spec.ts
@@ -9,8 +9,7 @@ import { navigateToPage } from "./utils/navigateToPage";
 import { openContextMenu } from "./utils/openContextMenu";
 import { submitInputText } from "./utils/submitInputText";
 
-// TODO [PRO-664] Re-enable this test
-test.skip("test-suites-tests-1: sorting and filtering test runs", async ({ page }) => {
+test("test-suites-tests-1: sorting and filtering test runs", async ({ page }) => {
   await navigateToPage({
     mockGraphQLData,
     page,

--- a/tests/test-suites-tests-2.spec.ts
+++ b/tests/test-suites-tests-2.spec.ts
@@ -10,8 +10,7 @@ import { getTestExecutionRow } from "./utils/getTestExecutionRow";
 import { getTestSummaryRow } from "./utils/getTestSummaryRow";
 import { navigateToPage } from "./utils/navigateToPage";
 
-// TODO [PRO-664] Re-enable this test
-test.skip("test-suites-tests-2: failed test executions", async ({ page }) => {
+test("test-suites-tests-2: failed test executions", async ({ page }) => {
   await navigateToPage({
     mockGraphQLData,
     page,

--- a/tests/test-suites-tests-3.spec.ts
+++ b/tests/test-suites-tests-3.spec.ts
@@ -10,8 +10,7 @@ import { getTestExecutionRow } from "./utils/getTestExecutionRow";
 import { getTestSummaryRow } from "./utils/getTestSummaryRow";
 import { navigateToPage } from "./utils/navigateToPage";
 
-// TODO [PRO-664] Re-enable this test
-test.skip("test-suites-tests-3: flaky test executions", async ({ page }) => {
+test("test-suites-tests-3: flaky test executions", async ({ page }) => {
   await navigateToPage({
     mockGraphQLData,
     page,

--- a/tests/test-suites-tests-4.spec.ts
+++ b/tests/test-suites-tests-4.spec.ts
@@ -12,9 +12,9 @@ import { getRecordingRow } from "./utils/getRecordingRow";
 import { getTestExecutionRow } from "./utils/getTestExecutionRow";
 import { getTestSummaryRow } from "./utils/getTestSummaryRow";
 import { navigateToPage } from "./utils/navigateToPage";
+import exp from "constants";
 
-// TODO [PRO-664] Re-enable this test
-test.skip("test-suites-tests-4: should respect workspace retention limits", async ({ page }) => {
+test("test-suites-tests-4: should respect workspace retention limits", async ({ page }) => {
   await navigateToPage({
     mockGraphQLData,
     page,

--- a/tests/test-suites-tests-5.spec.ts
+++ b/tests/test-suites-tests-5.spec.ts
@@ -9,10 +9,7 @@ import { getRecordingRow } from "./utils/getRecordingRow";
 import { getTestSummaryRow } from "./utils/getTestSummaryRow";
 import { navigateToPage } from "./utils/navigateToPage";
 
-// TODO [PRO-664] Re-enable this test
-test.skip("test-suites-tests-5: should handle when filters hide a selected test", async ({
-  page,
-}) => {
+test("test-suites-tests-5: should handle when filters hide a selected test", async ({ page }) => {
   await navigateToPage({
     mockGraphQLData,
     page,

--- a/tests/test-suites-tests-6.spec.ts
+++ b/tests/test-suites-tests-6.spec.ts
@@ -6,8 +6,7 @@ import { MockGraphQLData } from "./mocks/types";
 import { getTestSummaryRow } from "./utils/getTestSummaryRow";
 import { navigateToPage } from "./utils/navigateToPage";
 
-// TODO [PRO-664] Re-enable this test
-test.skip("test-suites-tests-6: should show a warning when a user opens a URL linking to a test that could not be loaded", async ({
+test("test-suites-tests-6: should show a warning when a user opens a URL linking to a test that could not be loaded", async ({
   page,
 }) => {
   const warningDialog = page.locator('[data-test-id="DeepLinkWarningDialog"]');


### PR DESCRIPTION
Reverts replayio/dashboard#154 Closes https://linear.app/replay/issue/PRO-664/re-enable-dashboard-tests-view-once-graphql-perf-issues-have-been.