### PR TITLE
Increase wait-for-Vercel timeout

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,7 @@ jobs:
         id: wait
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 120
+          max_timeout: 240
     outputs:
       preview_url: ${{ steps.wait.outputs.url }}
   generate-test-run-id:


### PR DESCRIPTION
This prematurely times out all the time and it's annoying. We should do this for the other repos too.