### PR TITLE
Try to fix rolling auth0 sessions

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { COOKIES, HEADERS } from "@/constants";
-import { getAccessToken } from "@auth0/nextjs-auth0/edge";
+import { getAccessToken, touchSession } from "@auth0/nextjs-auth0/edge";
 import { CookieSerializeOptions } from "cookie";
 import jwt from "jsonwebtoken";
 import { cookies } from "next/headers";
@@ -87,6 +87,8 @@ async function getAccessTokenForSession(request: NextRequest, response: NextResp
       token: null,
     };
   }
+
+  await touchSession();
 
   const cookieStore = cookies();
   const prevAccessTokenCookieRaw = cookieStore.get(COOKIES.accessToken);


### PR DESCRIPTION
Here's my theory why we're getting logged out from the app: I noticed that `getSession().accessToken` will not refresh the access token, so I used `getAccessToken()` instead. But apparently `getSession()` or `touchSession()` needs to be called to extend the lifetime of the Auth0 session.
Let's see if this helps.