### PR TITLE
Changing recording to replay

### DIFF
--- a/src/pageComponents/team/id/runs/TestExecutionRow.tsx
+++ b/src/pageComponents/team/id/runs/TestExecutionRow.tsx
@@ -24,7 +24,7 @@ export function TestExecutionRow({
       href={url ?? ""}
     >
       <Icon className={`w-6 h-6 shrink-0 ${colorClassName}`} type={iconType} />
-      <div className="truncate shrink">View recording</div>
+      <div className="truncate shrink">View replay</div>
       <div
         className="flex flex-row gap-1 items-center shrink-0 text-sm text-slate-300"
         suppressHydrationWarning

--- a/src/pageComponents/team/id/tests/RecordingRow.tsx
+++ b/src/pageComponents/team/id/tests/RecordingRow.tsx
@@ -31,7 +31,7 @@ export function RecordingRow({
         href={url ?? ""}
       >
         <Icon className={`w-6 h-6 shrink-0 ${colorClassName}`} type={iconType} />
-        <div className="truncate shrink">View recording</div>
+        <div className="truncate shrink">View replay</div>
       </Link>
     );
   } else {

--- a/tests/test-suites-runs-2.spec.ts
+++ b/tests/test-suites-runs-2.spec.ts
@@ -96,7 +96,7 @@ test("test-suites-runs-2: passed run in main branch with source", async ({ page 
     await expect(rows).toHaveCount(1);
 
     const text = await rows.textContent();
-    await expect(text).toContain("View recording");
+    await expect(text).toContain("View replay");
 
     const errors = page.locator('[data-test-id="TestExecution-Errors"]');
     await expect(errors).not.toBeVisible();

--- a/tests/test-suites-runs-5.spec.ts
+++ b/tests/test-suites-runs-5.spec.ts
@@ -67,7 +67,7 @@ test("test-suites-runs-5: should handle when filters hide a selected test run or
     const testRunRows = page.locator('[data-test-name="TestRunTests-Row"]');
     expect(testRunRows).toHaveCount(2);
     await testRunRows.first().click();
-    await expect(testDetails).toContainText("View recording");
+    await expect(testDetails).toContainText("View replay");
 
     // Change filters so that it's hidden and confirm 3rd column message
     await submitInputText(page, "TestRun-TextFilter", "Second");
@@ -85,7 +85,7 @@ test("test-suites-runs-5: should handle when filters hide a selected test run or
     // Confirm previous selection is restored
     await submitInputText(page, "TestRun-TextFilter", "");
     expect(testRunRows).toHaveCount(2);
-    await expect(testDetails).toContainText("View recording");
+    await expect(testDetails).toContainText("View replay");
   }
 });
 


### PR DESCRIPTION
As noted [here](https://www.notion.so/replayio/Documentation-Style-Guide-3bf7f3b1511e4f59a27322fdef693871?pvs=4), we say "replay" rather than "recording" across our product and in our documentation. This change aligns to that, and also adjusts our tests.

**Old:**
<img width="596" alt="image" src="https://github.com/replayio/dashboard/assets/9154902/6d635e5d-0f11-448b-b9aa-6073b463bb93">

**New:**
<img width="596" alt="image" src="https://github.com/replayio/dashboard/assets/9154902/f358794f-21d4-4362-bc92-9bfc7101bbb7">
