### PR TITLE
PRO-2372: capture ad attribution + forward to auth0 authorizationParams

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import { UserSettingsProvider } from "@/pageComponents/user/settings/UserSetting
 import { COOKIES, HEADERS } from "@/constants";
 import { getCurrentUser } from "@/graphql/queries/getCurrentUser";
 import { User } from "@/graphql/types";
+import { captureAdAttribution } from "@/utils/adAttribution";
 import { decompress } from "@/utils/compression";
 import { AccessTokenCookie, setCookieValueClient } from "@/utils/cookie";
 import { getValueFromArrayOrString } from "@/utils/getValueFromArrayOrString";
@@ -79,6 +80,11 @@ export default class MyApp extends App<AppProps<PageProps>> {
       });
     }
     initializeMixPanel();
+
+    // belt-and-suspenders: landing-page captures on replay.io first-touch,
+    // but users who land directly on app.replay.io (bookmark, direct ad
+    // URL) still need attribution captured here.
+    captureAdAttribution();
   }
 
   render() {

--- a/src/pages/api/auth/[auth0].ts
+++ b/src/pages/api/auth/[auth0].ts
@@ -16,6 +16,10 @@ export default handleAuth({
         prompt: getValueFromArrayOrString(req.query.prompt),
         connection: getValueFromArrayOrString(req.query.connection),
         redirect_uri: `${origin}/api/auth/callback`,
+        // ad attribution - forwarded to auth0 /authorize as custom query
+        // params so the post-login action can read them from
+        // event.request.query and pass to ensureUserForAuth.
+        ...pickAdAttributionParams(req),
       },
       returnTo,
     });
@@ -40,6 +44,29 @@ export default handleAuth({
     }
   },
 });
+
+// extracts ad-attribution query params that the devtools /login handler
+// forwarded here. these become custom /authorize query params that the
+// auth0 post-login action reads and passes to the backend.
+const AD_ATTR_KEYS = [
+  "li_fat_id",
+  "twclid",
+  "rdt_cid",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+] as const;
+
+function pickAdAttributionParams(req: NextApiRequest) {
+  const out: Record<string, string> = {};
+  for (const k of AD_ATTR_KEYS) {
+    const v = getValueFromArrayOrString(req.query[k]);
+    if (v) out[k] = v;
+  }
+  return out;
+}
 
 // This app also handles auth for the domain of the devtools app.
 function handleOriginAndReturnTo(req: NextApiRequest, res: NextApiResponse) {

--- a/src/pages/api/browser/auth.ts
+++ b/src/pages/api/browser/auth.ts
@@ -6,6 +6,17 @@ import { getAccessToken, getSession } from "@auth0/nextjs-auth0";
 import cookie from "cookie";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+const AD_ATTR_KEYS = [
+  "li_fat_id",
+  "twclid",
+  "rdt_cid",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+] as const;
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const key = getValueFromArrayOrString(req.query.key);
   const source = getValueFromArrayOrString(req.query.source) || "browser";
@@ -25,7 +36,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         })
       );
 
-      res.redirect("/login?returnTo=/api/browser/auth");
+      // carry ad-attribution query params through to /login so they flow
+      // into auth0's authorizationParams via /api/auth/login.
+      const loginParams: Record<string, string> = {
+        returnTo: "/api/browser/auth",
+      };
+      for (const k of AD_ATTR_KEYS) {
+        const v = getValueFromArrayOrString(req.query[k]);
+        if (v) loginParams[k] = v;
+      }
+      res.redirect(`/login?${new URLSearchParams(loginParams)}`);
     } else {
       const browserAuth = req.cookies[COOKIES.browserAuth];
 

--- a/src/pages/api/browser/auth.ts
+++ b/src/pages/api/browser/auth.ts
@@ -6,17 +6,6 @@ import { getAccessToken, getSession } from "@auth0/nextjs-auth0";
 import cookie from "cookie";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-const AD_ATTR_KEYS = [
-  "li_fat_id",
-  "twclid",
-  "rdt_cid",
-  "utm_source",
-  "utm_medium",
-  "utm_campaign",
-  "utm_content",
-  "utm_term",
-] as const;
-
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const key = getValueFromArrayOrString(req.query.key);
   const source = getValueFromArrayOrString(req.query.source) || "browser";
@@ -36,16 +25,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         })
       );
 
-      // carry ad-attribution query params through to /login so they flow
-      // into auth0's authorizationParams via /api/auth/login.
-      const loginParams: Record<string, string> = {
-        returnTo: "/api/browser/auth",
-      };
-      for (const k of AD_ATTR_KEYS) {
-        const v = getValueFromArrayOrString(req.query[k]);
-        if (v) loginParams[k] = v;
-      }
-      res.redirect(`/login?${new URLSearchParams(loginParams)}`);
+      res.redirect("/login?returnTo=/api/browser/auth");
     } else {
       const browserAuth = req.cookies[COOKIES.browserAuth];
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -10,6 +10,17 @@ import { useContext, useEffect, useState } from "react";
 const defaultConnection = "google-oauth2";
 const emailConnection = "Username-Password-Authentication";
 
+const AD_ATTR_KEYS = [
+  "li_fat_id",
+  "twclid",
+  "rdt_cid",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+] as const;
+
 export default function Page() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -21,11 +32,19 @@ export default function Page() {
   const [isMounted, setIsMounted] = useState(false);
 
   function onLogin(connection: string) {
-    let authUrl = `/api/auth/login?${new URLSearchParams({
+    const params: Record<string, string> = {
       connection,
       returnTo,
       origin: location.origin,
-    })}`;
+    };
+    // forward any ad-attribution params the upstream caller (devtools
+    // login() or /api/browser/auth) put on the URL so /api/auth/login
+    // can include them as auth0 authorizationParams.
+    for (const k of AD_ATTR_KEYS) {
+      const v = searchParams?.get(k);
+      if (v) params[k] = v;
+    }
+    let authUrl = `/api/auth/login?${new URLSearchParams(params)}`;
     if (switchAccount || isExternalAuth) {
       authUrl += "&prompt=login";
     }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -4,6 +4,7 @@ import { AccountSwitcherForm } from "@/pageComponents/login/AccountSwitcherForm"
 import { DefaultLoginForm } from "@/pageComponents/login/DefaultLoginForm";
 import { ReplayBrowserLoginForm } from "@/pageComponents/login/ReplayBrowserLoginForm";
 import { SSOLoginForm } from "@/pageComponents/login/SSOLoginForm";
+import { readAdAttribution } from "@/utils/adAttribution";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useContext, useEffect, useState } from "react";
 
@@ -37,11 +38,14 @@ export default function Page() {
       returnTo,
       origin: location.origin,
     };
-    // forward any ad-attribution params the upstream caller (devtools
-    // login() or /api/browser/auth) put on the URL so /api/auth/login
-    // can include them as auth0 authorizationParams.
+    // prefer any ad-attribution params on the current URL (freshest),
+    // fall back to the .replay.io cookie (written by landing-page on
+    // first-touch or by this dashboard's _app.tsx on direct landings).
+    // these become /api/auth/login query params which [auth0].ts spreads
+    // into auth0 authorizationParams -> post-login action -> backend.
+    const cookieAttribution = readAdAttribution();
     for (const k of AD_ATTR_KEYS) {
-      const v = searchParams?.get(k);
+      const v = searchParams?.get(k) ?? cookieAttribution?.[k];
       if (v) params[k] = v;
     }
     let authUrl = `/api/auth/login?${new URLSearchParams(params)}`;

--- a/src/utils/adAttribution.ts
+++ b/src/utils/adAttribution.ts
@@ -71,9 +71,10 @@ export function readAdAttribution(): AdAttribution | null {
   const match = document.cookie.match(
     new RegExp("(?:^|;\\s*)" + COOKIE_NAME + "=([^;]+)")
   );
-  if (!match) return null;
+  const raw = match?.[1];
+  if (!raw) return null;
   try {
-    return JSON.parse(decodeURIComponent(match[1])) as AdAttribution;
+    return JSON.parse(decodeURIComponent(raw)) as AdAttribution;
   } catch {
     return null;
   }

--- a/src/utils/adAttribution.ts
+++ b/src/utils/adAttribution.ts
@@ -1,0 +1,91 @@
+// first-touch capture of paid-ad click IDs + utm params. writes a
+// .replay.io cookie so the value survives the replay.io -> app.replay.io
+// subdomain jump (localStorage is origin-scoped and wouldn't). landing-page
+// writes the same cookie for users who land on the marketing site first;
+// dashboard both reads the cookie AND writes it so a direct ad -> app.replay.io
+// hit is still captured.
+
+const COOKIE_NAME = "replay-ad-attribution";
+// 90 days - matches the CVR window Tom called out for paid-ad platforms.
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 90;
+
+export type AdAttribution = {
+  li_fat_id?: string;
+  twclid?: string;
+  rdt_cid?: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
+};
+
+const AD_ATTR_KEYS = [
+  "li_fat_id",
+  "twclid",
+  "rdt_cid",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+] as const;
+
+// use Domain=.replay.io only when we're actually on a replay.io host,
+// so preview deploys (*.vercel.app) and localhost still write a working
+// host-only cookie.
+function cookieDomainAttribute(): string {
+  if (typeof window === "undefined") return "";
+  return window.location.hostname.endsWith("replay.io") ? "; Domain=.replay.io" : "";
+}
+
+function cookieSecureAttribute(): string {
+  if (typeof window === "undefined") return "";
+  return window.location.protocol === "https:" ? "; Secure" : "";
+}
+
+export function captureAdAttribution(): void {
+  if (typeof window === "undefined") return;
+  if (readAdAttribution()) return;
+
+  const params = new URLSearchParams(window.location.search);
+  const captured: AdAttribution = {};
+  for (const k of AD_ATTR_KEYS) {
+    const v = params.get(k);
+    if (v) captured[k] = v;
+  }
+  if (Object.keys(captured).length === 0) return;
+
+  const value = encodeURIComponent(JSON.stringify(captured));
+  document.cookie =
+    `${COOKIE_NAME}=${value}` +
+    `; Path=/` +
+    `; Max-Age=${COOKIE_MAX_AGE_SECONDS}` +
+    `; SameSite=Lax` +
+    cookieDomainAttribute() +
+    cookieSecureAttribute();
+}
+
+export function readAdAttribution(): AdAttribution | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp("(?:^|;\\s*)" + COOKIE_NAME + "=([^;]+)")
+  );
+  if (!match) return null;
+  try {
+    return JSON.parse(decodeURIComponent(match[1])) as AdAttribution;
+  } catch {
+    return null;
+  }
+}
+
+export function clearAdAttribution(): void {
+  if (typeof document === "undefined") return;
+  document.cookie =
+    `${COOKIE_NAME}=` +
+    `; Path=/` +
+    `; Max-Age=0` +
+    `; SameSite=Lax` +
+    cookieDomainAttribute() +
+    cookieSecureAttribute();
+}

--- a/src/utils/adAttribution.ts
+++ b/src/utils/adAttribution.ts
@@ -68,9 +68,7 @@ export function captureAdAttribution(): void {
 
 export function readAdAttribution(): AdAttribution | null {
   if (typeof document === "undefined") return null;
-  const match = document.cookie.match(
-    new RegExp("(?:^|;\\s*)" + COOKIE_NAME + "=([^;]+)")
-  );
+  const match = document.cookie.match(new RegExp("(?:^|;\\s*)" + COOKIE_NAME + "=([^;]+)"));
   const raw = match?.[1];
   if (!raw) return null;
   try {


### PR DESCRIPTION
captures paid-ad click IDs (`li_fat_id`, `twclid`, `rdt_cid`) + UTMs to a `.replay.io` cookie and threads them into auth0 `authorizationParams` at sign-up time. ticket: PRO-2372.

## shape

- **`_app.tsx`**: `captureAdAttribution()` runs in `componentDidMount` — belt-and-suspenders for users who land directly on `app.replay.io`. primary capture is on `replay.io` (landing-page), which is where all paid ads direct today.
- **`/login.tsx`**: reads attribution from URL params first (freshest), falls back to the `replay-ad-attribution` cookie, forwards to `/api/auth/login`.
- **`/api/auth/[auth0].ts`**: spreads those params into `authorizationParams`, which `@auth0/nextjs-auth0` forwards to `/authorize` as query params. auth0's post-login action reads `event.request.query.*` and hands them to the backend mutation.
- cookie: `Domain=.replay.io; SameSite=Lax; Secure; Max-Age=7776000` (90d, matching the ad CVR window). URI-encoded JSON. **first-touch** — never overwritten once set.

## test plan

- [x] `pnpm prettier:ci` clean
- [x] `pnpm typescript` clean on changed files
- [ ] manual: `https://app.replay.io/?li_fat_id=smoke` -> cookie set -> click sign up -> `/api/auth/login` + `/authorize` both include `li_fat_id=smoke`
- [ ] navigate away (no URL params) -> click sign up -> still forwarded from cookie
- [ ] clear cookie + visit without params -> no ad keys on `/api/auth/login`