### PR TITLE
Display AI tool calls in run details

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,7 @@ export const URLS = {
   app: process.env.NEXT_PUBLIC_VERCEL_URL
     ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
     : process.env.APP_URL!,
+  dispatch: process.env.NEXT_PUBLIC_DISPATCH_URL || "https://dispatch.replay.io",
 };
 
 export const TEST_USER_3 = {

--- a/src/pageComponents/team/id/runs/AIToolCalls.tsx
+++ b/src/pageComponents/team/id/runs/AIToolCalls.tsx
@@ -1,0 +1,262 @@
+import { SessionContext } from "@/components/SessionContext";
+import { URLS } from "@/constants";
+import { TestSuiteTest } from "@/graphql/types";
+import {
+  AIToolCall,
+  formatToolValue,
+  parseClaudeToolCalls,
+} from "@/pageComponents/team/id/runs/aiToolCallsLog";
+import { ExpandableSection } from "@/pageComponents/team/id/runs/ExpandableSection";
+import { useContext, useEffect, useMemo, useState } from "react";
+
+const CLAUDE_RAW_LOG_FILE_NAME = "claude-raw-log.jsonl";
+
+type ToolCallsState =
+  | { status: "idle"; toolCalls: AIToolCall[] }
+  | { status: "loading"; toolCalls: AIToolCall[] }
+  | { status: "missing"; toolCalls: AIToolCall[] }
+  | { status: "loaded"; toolCalls: AIToolCall[] }
+  | { status: "error"; error: string; toolCalls: AIToolCall[] };
+
+type RecordingToolCallsResult =
+  | { status: "found"; toolCalls: AIToolCall[] }
+  | { status: "missing" }
+  | { status: "error"; error: string };
+
+export function AIToolCalls({ test }: { test: TestSuiteTest }) {
+  const { accessToken } = useContext(SessionContext);
+  const recordingIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          test.executions.flatMap(execution => execution.recordings.map(recording => recording.id))
+        )
+      ),
+    [test]
+  );
+  const [state, setState] = useState<ToolCallsState>({
+    status: "idle",
+    toolCalls: [],
+  });
+
+  useEffect(() => {
+    if (recordingIds.length === 0) {
+      setState({ status: "idle", toolCalls: [] });
+      return;
+    }
+
+    const abortController = new AbortController();
+
+    setState({ status: "loading", toolCalls: [] });
+
+    void fetchToolCallsForRecordings({
+      accessToken,
+      recordingIds,
+      signal: abortController.signal,
+    })
+      .then(results => {
+        const foundResults = results.filter(isFoundResult);
+        const toolCalls = foundResults.flatMap(result => result.toolCalls);
+
+        if (foundResults.length > 0) {
+          setState({ status: "loaded", toolCalls });
+          return;
+        }
+
+        const firstError = results.find(result => result.status === "error");
+        if (firstError?.status === "error") {
+          setState({ status: "error", error: firstError.error, toolCalls: [] });
+        } else {
+          setState({ status: "missing", toolCalls: [] });
+        }
+      })
+      .catch(error => {
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        setState({
+          status: "error",
+          error: error instanceof Error ? error.message : String(error),
+          toolCalls: [],
+        });
+      });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [accessToken, recordingIds]);
+
+  if (state.status === "idle" || state.status === "missing") {
+    return null;
+  }
+
+  const hasMultipleRecordings = recordingIds.length > 1;
+
+  return (
+    <div
+      className="bg-background text-foreground p-2 rounded"
+      data-test-id="TestExecution-AIToolCalls"
+    >
+      <ExpandableSection
+        label={
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate">AI Tool Calls</span>
+            {state.toolCalls.length > 0 && (
+              <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                {state.toolCalls.length}
+              </span>
+            )}
+          </span>
+        }
+        openByDefault
+      >
+        {state.status === "loading" ? (
+          <div className="text-sm text-muted-foreground">Loading AI tool calls...</div>
+        ) : state.status === "error" ? (
+          <div className="text-sm text-muted-foreground break-words">{state.error}</div>
+        ) : state.toolCalls.length === 0 ? (
+          <div className="text-sm text-muted-foreground">
+            No AI tool calls found in the raw log.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {state.toolCalls.map(toolCall => (
+              <AIToolCallRow
+                hasMultipleRecordings={hasMultipleRecordings}
+                key={`${toolCall.recordingId}-${toolCall.id}`}
+                toolCall={toolCall}
+              />
+            ))}
+          </div>
+        )}
+      </ExpandableSection>
+    </div>
+  );
+}
+
+function AIToolCallRow({
+  hasMultipleRecordings,
+  toolCall,
+}: {
+  hasMultipleRecordings: boolean;
+  toolCall: AIToolCall;
+}) {
+  const input = formatToolValue(toolCall.input);
+
+  return (
+    <div
+      className="flex flex-col gap-2 bg-muted p-2 rounded shrink-0"
+      data-test-name="TestExecution-AIToolCall-Row"
+    >
+      <div className="flex flex-row gap-2 items-center overflow-hidden">
+        <div className="flex items-center justify-center bg-foreground text-background w-6 h-6 rounded shrink-0 text-xs">
+          {toolCall.sequence}
+        </div>
+        <div className="truncate font-medium">{toolCall.name}</div>
+        {toolCall.isError && (
+          <div className="ml-auto shrink-0 rounded bg-rose-600 px-1.5 py-0.5 text-xs text-white">
+            Error
+          </div>
+        )}
+      </div>
+
+      {input && (
+        <pre
+          className="max-h-36 overflow-auto whitespace-pre-wrap break-words bg-background text-muted-foreground p-2 rounded text-xs"
+          data-test-name="TestExecution-AIToolCall-Input"
+        >
+          {input}
+        </pre>
+      )}
+
+      {toolCall.result && (
+        <pre
+          className="max-h-28 overflow-auto whitespace-pre-wrap break-words bg-background text-muted-foreground p-2 rounded text-xs"
+          data-test-name="TestExecution-AIToolCall-Result"
+        >
+          {toolCall.result}
+        </pre>
+      )}
+
+      {hasMultipleRecordings && (
+        <div className="truncate text-xs text-muted-foreground">{toolCall.recordingId}</div>
+      )}
+    </div>
+  );
+}
+
+function isFoundResult(
+  result: RecordingToolCallsResult
+): result is Extract<RecordingToolCallsResult, { status: "found" }> {
+  return result.status === "found";
+}
+
+async function fetchToolCallsForRecordings({
+  accessToken,
+  recordingIds,
+  signal,
+}: {
+  accessToken: string;
+  recordingIds: string[];
+  signal: AbortSignal;
+}): Promise<RecordingToolCallsResult[]> {
+  return await Promise.all(
+    recordingIds.map(recordingId =>
+      fetchToolCallsForRecording({ accessToken, recordingId, signal })
+    )
+  );
+}
+
+async function fetchToolCallsForRecording({
+  accessToken,
+  recordingId,
+  signal,
+}: {
+  accessToken: string;
+  recordingId: string;
+  signal: AbortSignal;
+}): Promise<RecordingToolCallsResult> {
+  let response: Response;
+  try {
+    response = await fetch(`${URLS.dispatch}/nut/fetch-analysis-artifact`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        fileName: CLAUDE_RAW_LOG_FILE_NAME,
+        recordingId,
+      }),
+      signal,
+    });
+  } catch (error) {
+    if (signal.aborted) {
+      throw error;
+    }
+
+    return {
+      status: "error",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (response.status === 404) {
+    return { status: "missing" };
+  }
+
+  if (!response.ok) {
+    return {
+      status: "error",
+      error: `AI tool call log request failed with ${response.status} ${
+        response.statusText
+      }: ${await response.text()}`,
+    };
+  }
+
+  return {
+    status: "found",
+    toolCalls: parseClaudeToolCalls(await response.text(), recordingId),
+  };
+}

--- a/src/pageComponents/team/id/runs/TestsAndExecutions.tsx
+++ b/src/pageComponents/team/id/runs/TestsAndExecutions.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@/components/Icon";
 import { LoadingProgressBar } from "@/components/LoadingProgressBar";
+import { AIToolCalls } from "@/pageComponents/team/id/runs/AIToolCalls";
 import { CenterAlignedPrompt } from "@/pageComponents/team/id/runs/CenterAlignedPrompt";
 import { ExpandableSection } from "@/pageComponents/team/id/runs/ExpandableSection";
 import { TestExecutionRow } from "@/pageComponents/team/id/runs/TestExecutionRow";
@@ -72,6 +73,7 @@ export function TestsAndExecutions() {
         </TestExecutionMessage>
       )}
 
+      <AIToolCalls test={selectedTest} />
       <TestRunErrors test={selectedTest} />
     </>
   );

--- a/src/pageComponents/team/id/runs/aiToolCallsLog.test.ts
+++ b/src/pageComponents/team/id/runs/aiToolCallsLog.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "@jest/globals";
+import { formatToolValue, parseClaudeToolCalls } from "./aiToolCallsLog";
+
+describe("parseClaudeToolCalls", () => {
+  it("extracts Claude tool calls and attaches matching tool results", () => {
+    const rawLog = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "Bash",
+              input: { command: "pnpm test" },
+            },
+          ],
+        },
+      }),
+      "not json",
+      JSON.stringify({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: "tests passed",
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_2",
+              name: "Read",
+              input: { file_path: "src/App.tsx" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_2",
+              content: [{ text: "file contents", type: "text" }],
+              is_error: true,
+            },
+          ],
+        },
+      }),
+    ].join("\n");
+
+    expect(parseClaudeToolCalls(rawLog, "recording-1")).toEqual([
+      {
+        id: "toolu_1",
+        input: { command: "pnpm test" },
+        isError: false,
+        name: "Bash",
+        recordingId: "recording-1",
+        result: "tests passed",
+        sequence: 1,
+      },
+      {
+        id: "toolu_2",
+        input: { file_path: "src/App.tsx" },
+        isError: true,
+        name: "Read",
+        recordingId: "recording-1",
+        result: "file contents",
+        sequence: 2,
+      },
+    ]);
+  });
+});
+
+describe("formatToolValue", () => {
+  it("formats strings and structured values for display", () => {
+    expect(formatToolValue(" value \n")).toBe("value");
+    expect(formatToolValue({ command: "pnpm test" })).toBe('{\n  "command": "pnpm test"\n}');
+  });
+});

--- a/src/pageComponents/team/id/runs/aiToolCallsLog.ts
+++ b/src/pageComponents/team/id/runs/aiToolCallsLog.ts
@@ -1,0 +1,112 @@
+export type AIToolCall = {
+  id: string;
+  input: unknown;
+  isError: boolean;
+  name: string;
+  recordingId: string;
+  result: string | null;
+  sequence: number;
+};
+
+export function parseClaudeToolCalls(rawLog: string, recordingId: string): AIToolCall[] {
+  const toolCalls: AIToolCall[] = [];
+  const toolCallsById = new Map<string, AIToolCall>();
+
+  for (const line of rawLog.split(/\r?\n/)) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine) {
+      continue;
+    }
+
+    let event: unknown;
+    try {
+      event = JSON.parse(trimmedLine);
+    } catch {
+      continue;
+    }
+
+    const content = getMessageContent(event);
+    if (!content) {
+      continue;
+    }
+
+    for (const block of content) {
+      if (!isObject(block)) {
+        continue;
+      }
+
+      if (block.type === "tool_use") {
+        const sequence = toolCalls.length + 1;
+        const toolUseId = typeof block.id === "string" ? block.id : null;
+        const toolCall: AIToolCall = {
+          id: toolUseId ?? `${recordingId}-${sequence}`,
+          input: block.input ?? null,
+          isError: false,
+          name: typeof block.name === "string" ? block.name : "unknown",
+          recordingId,
+          result: null,
+          sequence,
+        };
+
+        toolCalls.push(toolCall);
+        if (toolUseId) {
+          toolCallsById.set(toolUseId, toolCall);
+        }
+      } else if (block.type === "tool_result") {
+        const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : null;
+        const toolCall = toolUseId ? toolCallsById.get(toolUseId) : undefined;
+        if (toolCall) {
+          toolCall.result = formatToolResultValue(block.content ?? null);
+          toolCall.isError = block.is_error === true;
+        }
+      }
+    }
+  }
+
+  return toolCalls;
+}
+
+export function formatToolValue(value: unknown) {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+
+  if (value == null) {
+    return "";
+  }
+
+  return JSON.stringify(value, null, 2);
+}
+
+function getMessageContent(event: unknown): unknown[] | null {
+  if (!isObject(event) || !isObject(event.message)) {
+    return null;
+  }
+
+  const { content } = event.message;
+  return Array.isArray(content) ? content : null;
+}
+
+function formatToolResultValue(value: unknown) {
+  if (Array.isArray(value)) {
+    const text = value
+      .map(block => {
+        if (isObject(block) && typeof block.text === "string") {
+          return block.text.trim();
+        }
+        return null;
+      })
+      .filter((text): text is string => Boolean(text))
+      .join("\n");
+
+    if (text) {
+      return text;
+    }
+  }
+
+  return formatToolValue(value);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/test-suites-runs-3.spec.ts
+++ b/tests/test-suites-runs-3.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { mockGetTests } from "tests/mocks/utils/mockGetTests";
 import { mockGetTestsRunsForWorkspace } from "tests/mocks/utils/mockGetTestsRunsForWorkspace";
+import { mockGetWorkspace } from "tests/mocks/utils/mockGetWorkspace";
 import { partialToTestSuiteTest } from "tests/mocks/utils/partialToTestSuiteTest";
 import { partialToTestSuiteTestRecording } from "tests/mocks/utils/partialToTestSuiteTestRecording";
 import { DEFAULT_WORKSPACE_ID } from "./mocks/constants";
@@ -12,7 +13,77 @@ import { navigateToPage } from "./utils/navigateToPage";
 import { openContextMenu } from "./utils/openContextMenu";
 import { waitForUrlChange } from "./utils/waitForUrlChange";
 
+const EIGHTH_TEST_RECORDING_ID = "recording-eighth-test-ai-tool-calls";
+const EIGHTH_TEST_RECORDING_ID_2 = "recording-eighth-test-missing-ai-tool-calls";
+const AI_TOOL_CALLS_LOG = [
+  JSON.stringify({
+    type: "assistant",
+    message: {
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_bash",
+          name: "Bash",
+          input: { command: "pnpm test" },
+        },
+      ],
+    },
+  }),
+  JSON.stringify({
+    type: "user",
+    message: {
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_bash",
+          content: "tests passed",
+        },
+      ],
+    },
+  }),
+].join("\n");
+
 test("test-suites-runs-3: failed run in temp branch without source", async ({ page }) => {
+  await page.route("**/nut/fetch-analysis-artifact", async route => {
+    const corsHeaders = {
+      "access-control-allow-headers": "authorization, content-type",
+      "access-control-allow-methods": "POST, OPTIONS",
+      "access-control-allow-origin": "*",
+    };
+
+    if (route.request().method() === "OPTIONS") {
+      await route.fulfill({
+        headers: corsHeaders,
+        status: 204,
+      });
+      return;
+    }
+
+    const postData = route.request().postDataJSON() as {
+      fileName?: string;
+      recordingId?: string;
+    };
+
+    if (
+      postData.fileName === "claude-raw-log.jsonl" &&
+      postData.recordingId === EIGHTH_TEST_RECORDING_ID
+    ) {
+      await route.fulfill({
+        body: AI_TOOL_CALLS_LOG,
+        contentType: "application/x-ndjson",
+        headers: corsHeaders,
+        status: 200,
+      });
+    } else {
+      await route.fulfill({
+        body: "missing",
+        contentType: "text/plain",
+        headers: corsHeaders,
+        status: 404,
+      });
+    }
+  });
+
   await navigateToPage({
     mockGraphQLData,
     page,
@@ -117,6 +188,15 @@ test("test-suites-runs-3: failed run in temp branch without source", async ({ pa
     const rows = page.locator('[data-test-name="TestExecution-RecordingRow"]');
     await expect(rows).toHaveCount(2);
 
+    const aiToolCalls = page.locator('[data-test-id="TestExecution-AIToolCalls"]');
+    await expect(aiToolCalls).toBeVisible();
+    await expect(
+      aiToolCalls.locator('[data-test-name="TestExecution-AIToolCall-Row"]')
+    ).toHaveCount(1);
+    await expect(aiToolCalls).toContainText("Bash");
+    await expect(aiToolCalls).toContainText("pnpm test");
+    await expect(aiToolCalls).toContainText("tests passed");
+
     const errors = page.locator('[data-test-id="TestExecution-Errors"]');
     await expect(errors).toBeVisible();
     const errorRows = errors.locator('[data-test-name="TestExecution-Error-Row"]');
@@ -141,11 +221,16 @@ test("test-suites-runs-3: failed run in temp branch without source", async ({ pa
     await expect(await selectedTestsRow.textContent()).toContain("Eighth test");
 
     await expect(page.locator('[data-test-name="TestExecution-RecordingRow"]')).toHaveCount(2);
+    await expect(page.locator('[data-test-id="TestExecution-AIToolCalls"]')).toBeVisible();
     await expect(page.locator('[data-test-id="TestExecution-Errors"]')).toBeVisible();
   }
 });
 
 const mockGraphQLData: MockGraphQLData = {
+  GetWorkspace: mockGetWorkspace({
+    isTest: true,
+    retentionLimitDays: 30,
+  }),
   GetTests: mockGetTests([
     partialToTestSuiteTest({
       status: "passed",
@@ -192,7 +277,10 @@ const mockGraphQLData: MockGraphQLData = {
       errors: ["This is an error message"],
       executions: [
         {
-          recordings: [partialToTestSuiteTestRecording(), partialToTestSuiteTestRecording()],
+          recordings: [
+            partialToTestSuiteTestRecording({ id: EIGHTH_TEST_RECORDING_ID }),
+            partialToTestSuiteTestRecording({ id: EIGHTH_TEST_RECORDING_ID_2 }),
+          ],
         },
       ],
       status: "flaky",


### PR DESCRIPTION
## Summary
- fetch the Claude raw JSONL analysis artifact for selected test recordings through `/nut/fetch-analysis-artifact`
- parse Claude `tool_use` and `tool_result` entries into displayable AI tool call rows
- add an AI Tool Calls section to the right-side run details panel

## Validation
- `pnpm exec jest src/pageComponents/team/id/runs/aiToolCallsLog.test.ts --runInBand`
- `pnpm typescript`
- `pnpm lint`

## Notes
- Focused Playwright coverage was updated for the artifact fetch path. A local run was blocked by the existing workspace permission gate before reaching the runs page.